### PR TITLE
refactor: remove deprecated JWT functions

### DIFF
--- a/apps/api/src/auth/__tests__/token.test.ts
+++ b/apps/api/src/auth/__tests__/token.test.ts
@@ -9,8 +9,6 @@ import { createMockUser } from '../../schema/user/__mocks__/user.js';
 import { createMockGoogleTokenPayload } from '../__mocks__/token.js';
 import {
     verifyGoogleToken,
-    generateJWT,
-    verifyJWT,
     generateAccessToken,
     verifyAccessToken,
     generateRefreshToken,
@@ -176,107 +174,6 @@ describe('Token utilities', () => {
             });
 
             const result = verifyAccessToken(token);
-
-            expect(result).toBeNull();
-        });
-    });
-
-    describe('generateJWT (backward compatibility)', () => {
-        it('should generate a JWT token with user payload', () => {
-            const mockUser = createMockUser();
-            const payload = {
-                userId: mockUser.id,
-                email: mockUser.email
-            };
-            const mockToken = 'mock.jwt.token';
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            vi.mocked(jwt.sign).mockReturnValue(mockToken as any);
-
-            const result = generateJWT(payload);
-
-            expect(result).toBe(mockToken);
-            expect(jwt.sign).toHaveBeenCalledWith(payload, 'mock-jwt-secret', { expiresIn: 900 });
-        });
-
-        it('should generate different tokens for different users', () => {
-            const user1 = createMockUser({ id: 'user-1', email: 'user1@example.com' });
-            const user2 = createMockUser({ id: 'user-2', email: 'user2@example.com' });
-
-            vi.mocked(jwt.sign)
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .mockReturnValueOnce('token1' as any)
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .mockReturnValueOnce('token2' as any);
-
-            const token1 = generateJWT({ userId: user1.id, email: user1.email });
-            const token2 = generateJWT({ userId: user2.id, email: user2.email });
-
-            expect(token1).not.toBe(token2);
-            expect(jwt.sign).toHaveBeenCalledTimes(2);
-        });
-    });
-
-    describe('verifyJWT (backward compatibility)', () => {
-        it('should verify a valid JWT token and return payload', () => {
-            const token = 'valid.jwt.token';
-            const mockPayload = {
-                userId: 'user-123',
-                email: 'user@example.com',
-                iat: Math.floor(Date.now() / 1000),
-                exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
-            };
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            vi.mocked(jwt.verify).mockReturnValue(mockPayload as any);
-
-            const result = verifyJWT(token);
-
-            expect(result).toEqual(mockPayload);
-            expect(jwt.verify).toHaveBeenCalledWith(token, 'mock-jwt-secret');
-        });
-
-        it('should return null when token verification fails', () => {
-            const token = 'invalid.jwt.token';
-            vi.mocked(jwt.verify).mockImplementation(() => {
-                throw new Error('Invalid token');
-            });
-
-            const result = verifyJWT(token);
-
-            expect(result).toBeNull();
-            expect(jwt.verify).toHaveBeenCalledWith(token, 'mock-jwt-secret');
-        });
-
-        it('should return null when token is expired', () => {
-            const token = 'expired.jwt.token';
-            vi.mocked(jwt.verify).mockImplementation(() => {
-                throw new jwt.TokenExpiredError('Token expired', new Date());
-            });
-
-            const result = verifyJWT(token);
-
-            expect(result).toBeNull();
-        });
-
-        it('should return null when token has invalid signature', () => {
-            const token = 'tampered.jwt.token';
-            vi.mocked(jwt.verify).mockImplementation(() => {
-                throw new jwt.JsonWebTokenError('Invalid signature');
-            });
-
-            const result = verifyJWT(token);
-
-            expect(result).toBeNull();
-        });
-
-        it('should return null when token is malformed', () => {
-            const token = 'not-a-jwt';
-            vi.mocked(jwt.verify).mockImplementation(() => {
-                throw new jwt.JsonWebTokenError('jwt malformed');
-            });
-
-            const result = verifyJWT(token);
 
             expect(result).toBeNull();
         });
@@ -767,12 +664,12 @@ describe('Token utilities', () => {
             };
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             vi.mocked(jwt.sign).mockReturnValue('jwt.token' as any);
-            const jwtToken = generateJWT(jwtPayload);
+            const jwtToken = generateAccessToken(jwtPayload);
 
             // Verify JWT
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             vi.mocked(jwt.verify).mockReturnValue(jwtPayload as any);
-            const verifiedPayload = verifyJWT(jwtToken);
+            const verifiedPayload = verifyAccessToken(jwtToken);
 
             expect(verifiedPayload).toEqual(jwtPayload);
         });

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -27,6 +27,11 @@ export interface RefreshTokenData {
     tokenId: string;
 }
 
+/**
+ * Verifies a Google ID token and extracts the payload.
+ * @param token - The Google ID token to verify
+ * @returns The token payload if valid, null if verification fails
+ */
 export async function verifyGoogleToken(token: string) {
     try {
         const ticket = await client.verifyIdToken({
@@ -39,12 +44,22 @@ export async function verifyGoogleToken(token: string) {
     }
 }
 
+/**
+ * Generates a JWT access token for a user.
+ * @param payload - The token payload containing userId and email
+ * @returns A signed JWT access token
+ */
 export function generateAccessToken(payload: TokenPayload): string {
     return jwt.sign(payload, env.JWT_SECRET, {
         expiresIn: env.ACCESS_TOKEN_EXPIRES_IN_SECONDS
     });
 }
 
+/**
+ * Verifies a JWT access token and extracts the payload.
+ * @param token - The JWT access token to verify
+ * @returns The token payload if valid, null if verification fails
+ */
 export function verifyAccessToken(token: string): TokenPayload | null {
     try {
         return jwt.verify(token, env.JWT_SECRET) as TokenPayload;
@@ -53,25 +68,32 @@ export function verifyAccessToken(token: string): TokenPayload | null {
     }
 }
 
-// Keep old functions for backward compatibility during migration
-export function generateJWT(payload: { userId: string; email: string }) {
-    return generateAccessToken(payload);
-}
-
-export function verifyJWT(token: string) {
-    return verifyAccessToken(token);
-}
-
+/**
+ * Generates a cryptographically secure random refresh token.
+ * @returns A base64url encoded random token string
+ */
 export function generateRefreshToken(): string {
     // Generate a cryptographically secure random token
     return crypto.randomBytes(32).toString('base64url');
 }
 
+/**
+ * Hashes a refresh token using SHA-256 for secure storage.
+ * @param token - The refresh token to hash
+ * @returns The SHA-256 hash of the token as a hex string
+ */
 export function hashRefreshToken(token: string): string {
     // Hash the token before storing in database
     return crypto.createHash('sha256').update(token).digest('hex');
 }
 
+/**
+ * Creates a new refresh token for a user and stores it in the database.
+ * @param prisma - The Prisma client instance
+ * @param userId - The ID of the user to create the token for
+ * @param metadata - Optional metadata containing userAgent and ipAddress
+ * @returns The unhashed refresh token to be sent to the client
+ */
 export async function createRefreshToken(
     prisma: PrismaClient,
     userId: string,
@@ -94,6 +116,13 @@ export async function createRefreshToken(
     return token;
 }
 
+/**
+ * Validates a refresh token and returns the associated user data.
+ * Automatically deletes expired tokens and updates last used timestamp.
+ * @param prisma - The Prisma client instance
+ * @param token - The refresh token to validate
+ * @returns RefreshTokenData with userId and tokenId if valid, null otherwise
+ */
 export async function validateRefreshToken(prisma: PrismaClient, token: string): Promise<RefreshTokenData | null> {
     const hashedToken = hashRefreshToken(token);
 
@@ -125,6 +154,15 @@ export async function validateRefreshToken(prisma: PrismaClient, token: string):
     };
 }
 
+/**
+ * Rotates a refresh token by deleting the old one and creating a new one.
+ * Implements token rotation for enhanced security.
+ * @param prisma - The Prisma client instance
+ * @param oldTokenId - The ID of the refresh token to rotate
+ * @param metadata - Optional metadata containing userAgent and ipAddress
+ * @returns The new unhashed refresh token
+ * @throws Error if the old token is not found
+ */
 export async function rotateRefreshToken(
     prisma: PrismaClient,
     oldTokenId: string,
@@ -148,6 +186,12 @@ export async function rotateRefreshToken(
     return createRefreshToken(prisma, oldToken.userId, metadata);
 }
 
+/**
+ * Revokes a specific refresh token by removing it from the database.
+ * @param prisma - The Prisma client instance
+ * @param token - The refresh token to revoke
+ * @returns Promise that resolves when the token is revoked
+ */
 export async function revokeRefreshToken(prisma: PrismaClient, token: string): Promise<void> {
     const hashedToken = hashRefreshToken(token);
 
@@ -156,6 +200,13 @@ export async function revokeRefreshToken(prisma: PrismaClient, token: string): P
     });
 }
 
+/**
+ * Revokes all refresh tokens for a specific user.
+ * Useful for logout from all devices or security incidents.
+ * @param prisma - The Prisma client instance
+ * @param userId - The ID of the user whose tokens should be revoked
+ * @returns Promise that resolves when all tokens are revoked
+ */
 export async function revokeAllUserTokens(prisma: PrismaClient, userId: string): Promise<void> {
     await prisma.refreshToken.deleteMany({
         where: { userId }

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -3,7 +3,7 @@ import { User as UserModel } from '@prisma/client';
 import { parse as parseCookie } from 'cookie';
 import type { YogaInitialContext } from 'graphql-yoga';
 
-import { verifyJWT } from './auth/token.js';
+import { verifyAccessToken } from './auth/token.js';
 import { prisma } from './prisma/client.js';
 
 export type RequestMetadata = {
@@ -61,7 +61,7 @@ export async function createContext({ request, ...rest }: YogaInitialContext): P
 
     try {
         // Verify JWT token with better error handling
-        const jwtPayload = verifyJWT(token);
+        const jwtPayload = verifyAccessToken(token);
         if (!jwtPayload || !jwtPayload.userId) {
             return {
                 user: null,

--- a/apps/api/src/schema/user/__tests__/user.test.ts
+++ b/apps/api/src/schema/user/__tests__/user.test.ts
@@ -4,7 +4,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createMockGoogleTokenPayload } from '../../../auth/__mocks__/token.js';
 import {
     verifyGoogleToken,
-    generateJWT,
     generateAccessToken,
     createRefreshToken,
     validateRefreshToken,
@@ -26,7 +25,6 @@ vi.mock('../../../auth/token.js', async () => {
     return {
         ...originalModule,
         verifyGoogleToken: vi.fn(),
-        generateJWT: vi.fn(),
         generateAccessToken: vi.fn(),
         createRefreshToken: vi.fn(),
         validateRefreshToken: vi.fn(),
@@ -152,7 +150,6 @@ describe('User GraphQL', () => {
             prismaMock.user.findUnique.mockResolvedValue(mockUser);
 
             // Mock JWT generation
-            vi.mocked(generateJWT).mockReturnValue('jwt-token-123');
             vi.mocked(generateAccessToken).mockReturnValue('access-token-123');
             vi.mocked(createRefreshToken).mockResolvedValue('refresh-token-123');
             vi.mocked(serialize).mockReturnValue('refreshToken=refresh-token-123; HttpOnly');
@@ -167,7 +164,7 @@ describe('User GraphQL', () => {
 
             expect(errors).toBeUndefined();
             expect(data.googleOAuthLoginMutation).toEqual({
-                token: 'jwt-token-123',
+                token: 'access-token-123',
                 accessToken: 'access-token-123',
                 refreshToken: null, // Not returned for web clients
                 user: {
@@ -190,10 +187,6 @@ describe('User GraphQL', () => {
                 where: { googleId: 'google_123456' }
             });
             expect(prismaMock.user.create).not.toHaveBeenCalled();
-            expect(generateJWT).toHaveBeenCalledWith({
-                userId: mockUser.id,
-                email: mockUser.email
-            });
             expect(generateAccessToken).toHaveBeenCalledWith({
                 userId: mockUser.id,
                 email: mockUser.email
@@ -225,7 +218,6 @@ describe('User GraphQL', () => {
             prismaMock.user.findUnique.mockResolvedValue(mockUser);
 
             // Mock JWT generation
-            vi.mocked(generateJWT).mockReturnValue('jwt-token-123');
             vi.mocked(generateAccessToken).mockReturnValue('access-token-123');
             vi.mocked(createRefreshToken).mockResolvedValue('refresh-token-123');
 
@@ -239,7 +231,7 @@ describe('User GraphQL', () => {
 
             expect(errors).toBeUndefined();
             expect(data.googleOAuthLoginMutation).toEqual({
-                token: 'jwt-token-123',
+                token: 'access-token-123',
                 accessToken: 'access-token-123',
                 refreshToken: 'refresh-token-123', // Returned for mobile clients
                 user: {
@@ -281,7 +273,6 @@ describe('User GraphQL', () => {
             prismaMock.user.create.mockResolvedValue(mockNewUser);
 
             // Mock JWT generation
-            vi.mocked(generateJWT).mockReturnValue('jwt-token-456');
             vi.mocked(generateAccessToken).mockReturnValue('access-token-456');
             vi.mocked(createRefreshToken).mockResolvedValue('refresh-token-456');
             vi.mocked(serialize).mockReturnValue('refreshToken=refresh-token-456; HttpOnly');
@@ -296,7 +287,7 @@ describe('User GraphQL', () => {
 
             expect(errors).toBeUndefined();
             expect(data.googleOAuthLoginMutation).toEqual({
-                token: 'jwt-token-456',
+                token: 'access-token-456',
                 accessToken: 'access-token-456',
                 refreshToken: null,
                 user: {

--- a/apps/api/src/schema/user/index.ts
+++ b/apps/api/src/schema/user/index.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import {
     createRefreshToken,
     generateAccessToken,
-    generateJWT,
     revokeAllUserTokens,
     revokeRefreshToken,
     rotateRefreshToken,
@@ -85,7 +84,6 @@ const resolvers: Resolvers = {
 
                 // Generate tokens
                 const accessToken = generateAccessToken({ userId: user.id, email: user.email });
-                const token = generateJWT({ userId: user.id, email: user.email }); // For backward compatibility
 
                 // Create refresh token
                 const refreshToken = await createRefreshToken(prisma, user.id, requestMetadata);
@@ -95,7 +93,7 @@ const resolvers: Resolvers = {
                     response.headers.set('Set-Cookie', serialize('refreshToken', refreshToken, COOKIE_OPTIONS));
 
                     return {
-                        token,
+                        token: accessToken,
                         accessToken,
                         refreshToken: undefined,
                         user,
@@ -104,7 +102,7 @@ const resolvers: Resolvers = {
                 } else {
                     // Return refresh token in response for mobile clients
                     return {
-                        token,
+                        token: accessToken,
                         accessToken,
                         refreshToken,
                         user,

--- a/apps/api/src/testSetup.ts
+++ b/apps/api/src/testSetup.ts
@@ -1,5 +1,14 @@
 import { vi } from 'vitest';
 
+// Set up test environment variables before importing any modules
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+process.env.GOOGLE_CLIENT_ID = 'test-google-client-id';
+process.env.CLIENT_URL = 'http://localhost:3000';
+process.env.JWT_SECRET = 'test-jwt-secret';
+process.env.REFRESH_TOKEN_EXPIRES_IN_DAYS = '30';
+process.env.ACCESS_TOKEN_EXPIRES_IN_SECONDS = '900';
+
 // Mock Prisma Client
 vi.mock('./prisma/client.js', async () => {
     const prismaMock = await import('./prisma/__mocks__/client.js');


### PR DESCRIPTION
- Add JSDoc documentation to all exported functions in auth/token.ts
- Remove deprecated generateJWT() and verifyJWT() functions
- Update all imports and usages to use generateAccessToken() and verifyAccessToken()
- Update tests to use the new function names
- Fix test environment setup to include required environment variables
- Maintain backward compatibility by using accessToken for both token and accessToken fields

All tests pass with 100% coverage.