### PR TITLE
update authprovider to use tokenstorage service and sessionstorage

### DIFF
--- a/apps/web/src/apollo/client.ts
+++ b/apps/web/src/apollo/client.ts
@@ -3,6 +3,7 @@ import { setContext } from '@apollo/client/link/context';
 import { OperationDefinitionNode } from 'graphql';
 
 import { cache, setupCachePersistence } from './cache';
+import { tokenStorage } from './tokenStorage';
 
 import LoggableEventCard from '../components/EventCards/LoggableEventCard';
 import EventLabel from '../components/EventLabels/EventLabel';
@@ -259,7 +260,7 @@ const httpLink = createHttpLink({
 
 // Auth link to add authorization token to requests
 const authLink = setContext((_, { headers }) => {
-    const token = localStorage.getItem('token');
+    const token = tokenStorage.getAccessToken();
     return {
         headers: {
             ...headers,


### PR DESCRIPTION
This pull request refactors the authentication and storage mechanisms in the `AuthProvider` component, replacing `localStorage` with a new `tokenStorage` module for secure token management and `sessionStorage` for non-sensitive user data. It also updates the associated tests to reflect these changes.

### Authentication and Storage Refactor:
* [`apps/web/src/apollo/client.ts`](diffhunk://#diff-ebb306e2e3cceaa77a5c25c2eb1e907db606c6a9a137e1eb828f4742415ced52L262-R263): Replaced `localStorage.getItem('token')` with `tokenStorage.getAccessToken()` in the Apollo client setup.
* [`apps/web/src/providers/AuthProvider.tsx`](diffhunk://#diff-ef3d7fb136728647920343b38708bada32132a4b6052cdedc73b9736e56da640R43-R53): Updated `login` and `logout` methods to use `tokenStorage` for token management and `sessionStorage` for storing non-sensitive user data. Removed token restoration from storage and added comments for handling token refresh flow. [[1]](diffhunk://#diff-ef3d7fb136728647920343b38708bada32132a4b6052cdedc73b9736e56da640R43-R53) [[2]](diffhunk://#diff-ef3d7fb136728647920343b38708bada32132a4b6052cdedc73b9736e56da640L85-R99)

### Test Updates:
* [`apps/web/src/providers/__tests__/AuthProvider.test.js`](diffhunk://#diff-6f8ec2ac015a4778a134e904e63c512de19fad4a876ccf5d73e2fed59ac8eeceL30-R37): Replaced `localStorage` mocks with `sessionStorage` mocks and added `tokenStorage` mocks. Updated test cases to verify the new behavior for login, logout, and offline mode. [[1]](diffhunk://#diff-6f8ec2ac015a4778a134e904e63c512de19fad4a876ccf5d73e2fed59ac8eeceL30-R37) [[2]](diffhunk://#diff-6f8ec2ac015a4778a134e904e63c512de19fad4a876ccf5d73e2fed59ac8eeceL108-R115)
* [`apps/web/src/providers/__tests__/AuthProvider.test.js`](diffhunk://#diff-6f8ec2ac015a4778a134e904e63c512de19fad4a876ccf5d73e2fed59ac8eeceL387-R400): Modified tests to ensure user data is restored from `sessionStorage` and token refresh is required on page load. Removed tests for token restoration from storage. [[1]](diffhunk://#diff-6f8ec2ac015a4778a134e904e63c512de19fad4a876ccf5d73e2fed59ac8eeceL387-R400) [[2]](diffhunk://#diff-6f8ec2ac015a4778a134e904e63c512de19fad4a876ccf5d73e2fed59ac8eeceL439-R455)