### PR TITLE
create useAuthMutations hook

### DIFF
--- a/apps/web/src/hooks/__tests__/useAuthMutations.test.js
+++ b/apps/web/src/hooks/__tests__/useAuthMutations.test.js
@@ -1,0 +1,669 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { createMutationResponse } from '../../mocks/mutations';
+import {
+    useAuthMutations,
+    LOGIN_MUTATION,
+    REFRESH_TOKEN_MUTATION,
+    LOGOUT_MUTATION,
+    LOGOUT_ALL_DEVICES_MUTATION
+} from '../useAuthMutations';
+
+// Helper functions to create mutation responses
+const createLoginMutationResponse = ({
+    googleToken,
+    clientType = 'WEB',
+    accessToken = 'mock-access-token',
+    user = { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    apiErrors = [],
+    gqlError = null,
+    nullPayload = false,
+    delay = 0
+}) =>
+    createMutationResponse({
+        query: LOGIN_MUTATION,
+        input: {
+            googleToken,
+            clientType
+        },
+        mutationName: 'googleOAuthLoginMutation',
+        payload: {
+            __typename: 'GoogleOAuthLoginMutationPayload',
+            accessToken,
+            user: {
+                __typename: 'User',
+                ...user
+            }
+        },
+        delay,
+        gqlError,
+        apiErrors,
+        nullPayload
+    });
+
+const createRefreshTokenMutationResponse = ({
+    accessToken = 'new-access-token',
+    apiErrors = [],
+    gqlError = null,
+    nullPayload = false,
+    delay = 0
+}) => ({
+    request: {
+        query: REFRESH_TOKEN_MUTATION,
+        variables: {}
+    },
+    ...(delay > 0 ? { delay } : {}),
+    ...(gqlError
+        ? {
+              error: gqlError
+          }
+        : {
+              result: {
+                  data: {
+                      refreshTokenMutation: nullPayload
+                          ? null
+                          : {
+                                __typename: 'RefreshTokenMutationPayload',
+                                accessToken,
+                                errors: apiErrors
+                            }
+                  }
+              }
+          })
+});
+
+const createLogoutMutationResponse = ({
+    success = true,
+    apiErrors = [],
+    gqlError = null,
+    nullPayload = false,
+    delay = 0
+}) => ({
+    request: {
+        query: LOGOUT_MUTATION,
+        variables: {}
+    },
+    ...(delay > 0 ? { delay } : {}),
+    ...(gqlError
+        ? {
+              error: gqlError
+          }
+        : {
+              result: {
+                  data: {
+                      logoutMutation: nullPayload
+                          ? null
+                          : {
+                                __typename: 'LogoutMutationPayload',
+                                success,
+                                errors: apiErrors
+                            }
+                  }
+              }
+          })
+});
+
+const createLogoutAllDevicesMutationResponse = ({
+    success = true,
+    apiErrors = [],
+    gqlError = null,
+    nullPayload = false,
+    delay = 0
+}) => ({
+    request: {
+        query: LOGOUT_ALL_DEVICES_MUTATION,
+        variables: {}
+    },
+    ...(delay > 0 ? { delay } : {}),
+    ...(gqlError
+        ? {
+              error: gqlError
+          }
+        : {
+              result: {
+                  data: {
+                      logoutAllDevicesMutation: nullPayload
+                          ? null
+                          : {
+                                __typename: 'LogoutAllDevicesMutationPayload',
+                                success,
+                                errors: apiErrors
+                            }
+                  }
+              }
+          })
+});
+
+describe('useAuthMutations', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const renderHookWithProviders = ({ mocks = [] } = {}) => {
+        const wrapper = ({ children }) => (
+            <MockedProvider mocks={mocks} defaultOptions={{ watchQuery: { errorPolicy: 'all' } }}>
+                {children}
+            </MockedProvider>
+        );
+
+        return renderHook(() => useAuthMutations(), { wrapper });
+    };
+
+    describe('hook initialization', () => {
+        it('returns all expected mutations and loading states', () => {
+            const { result } = renderHookWithProviders();
+
+            expect(result.current.loginMutation).toBeInstanceOf(Function);
+            expect(result.current.refreshTokenMutation).toBeInstanceOf(Function);
+            expect(result.current.logoutMutation).toBeInstanceOf(Function);
+            expect(result.current.logoutAllDevicesMutation).toBeInstanceOf(Function);
+            expect(typeof result.current.loginLoading).toBe('boolean');
+            expect(typeof result.current.refreshLoading).toBe('boolean');
+            expect(typeof result.current.logoutLoading).toBe('boolean');
+            expect(typeof result.current.logoutAllLoading).toBe('boolean');
+            expect(typeof result.current.isLoading).toBe('boolean');
+        });
+
+        it('initializes with loading states as false', () => {
+            const { result } = renderHookWithProviders();
+
+            expect(result.current.loginLoading).toBe(false);
+            expect(result.current.refreshLoading).toBe(false);
+            expect(result.current.logoutLoading).toBe(false);
+            expect(result.current.logoutAllLoading).toBe(false);
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        it('returns error states', () => {
+            const { result } = renderHookWithProviders();
+
+            expect(result.current.loginError).toBeUndefined();
+            expect(result.current.refreshError).toBeUndefined();
+            expect(result.current.logoutError).toBeUndefined();
+            expect(result.current.logoutAllError).toBeUndefined();
+        });
+    });
+
+    describe('loginMutation', () => {
+        it.each([
+            [
+                'executes login mutation successfully',
+                {
+                    googleToken: 'google-oauth-token',
+                    clientType: 'WEB',
+                    accessToken: 'mock-access-token',
+                    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' }
+                },
+                {
+                    googleOAuthLoginMutation: {
+                        __typename: 'GoogleOAuthLoginMutationPayload',
+                        accessToken: 'mock-access-token',
+                        user: {
+                            __typename: 'User',
+                            id: 'user-1',
+                            email: 'test@example.com',
+                            name: 'Test User'
+                        },
+                        errors: []
+                    }
+                }
+            ],
+            [
+                'handles login with mobile client type',
+                {
+                    googleToken: 'google-oauth-token',
+                    clientType: 'MOBILE',
+                    accessToken: 'mobile-access-token',
+                    user: { id: 'user-2', email: 'mobile@example.com', name: 'Mobile User' }
+                },
+                {
+                    googleOAuthLoginMutation: {
+                        __typename: 'GoogleOAuthLoginMutationPayload',
+                        accessToken: 'mobile-access-token',
+                        user: {
+                            __typename: 'User',
+                            id: 'user-2',
+                            email: 'mobile@example.com',
+                            name: 'Mobile User'
+                        },
+                        errors: []
+                    }
+                }
+            ]
+        ])('%s', async (_, mockConfig, expectedData) => {
+            const mocks = [createLoginMutationResponse(mockConfig)];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                mutationResult = await result.current.loginMutation({
+                    variables: {
+                        input: {
+                            googleToken: mockConfig.googleToken,
+                            clientType: mockConfig.clientType
+                        }
+                    }
+                });
+            });
+
+            expect(mutationResult.data).toEqual(expectedData);
+        });
+
+        it('handles login mutation errors', async () => {
+            const mocks = [
+                createLoginMutationResponse({
+                    googleToken: 'invalid-token',
+                    gqlError: new Error('Authentication failed')
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            await act(async () => {
+                await expect(
+                    result.current.loginMutation({
+                        variables: {
+                            input: {
+                                googleToken: 'invalid-token',
+                                clientType: 'WEB'
+                            }
+                        }
+                    })
+                ).rejects.toThrow('Authentication failed');
+            });
+
+            expect(result.current.loginError).toBeDefined();
+        });
+    });
+
+    describe('refreshTokenMutation', () => {
+        it.each([
+            [
+                'refreshes token successfully',
+                {
+                    accessToken: 'refreshed-access-token'
+                },
+                {
+                    refreshTokenMutation: {
+                        __typename: 'RefreshTokenMutationPayload',
+                        accessToken: 'refreshed-access-token',
+                        errors: []
+                    }
+                }
+            ],
+            [
+                'handles refresh with new token',
+                {
+                    accessToken: 'brand-new-access-token'
+                },
+                {
+                    refreshTokenMutation: {
+                        __typename: 'RefreshTokenMutationPayload',
+                        accessToken: 'brand-new-access-token',
+                        errors: []
+                    }
+                }
+            ]
+        ])('%s', async (_, mockConfig, expectedData) => {
+            const mocks = [createRefreshTokenMutationResponse(mockConfig)];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                mutationResult = await result.current.refreshTokenMutation();
+            });
+
+            expect(mutationResult.data).toEqual(expectedData);
+        });
+
+        it('handles refresh token errors', async () => {
+            const mocks = [
+                createRefreshTokenMutationResponse({
+                    gqlError: new Error('Token expired')
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            await act(async () => {
+                await expect(result.current.refreshTokenMutation()).rejects.toThrow('Token expired');
+            });
+
+            expect(result.current.refreshError).toBeDefined();
+        });
+    });
+
+    describe('logoutMutation', () => {
+        it.each([
+            [
+                'executes logout successfully',
+                { success: true },
+                {
+                    logoutMutation: {
+                        __typename: 'LogoutMutationPayload',
+                        success: true,
+                        errors: []
+                    }
+                }
+            ],
+            [
+                'handles logout failure',
+                { success: false },
+                {
+                    logoutMutation: {
+                        __typename: 'LogoutMutationPayload',
+                        success: false,
+                        errors: []
+                    }
+                }
+            ]
+        ])('%s', async (_, mockConfig, expectedData) => {
+            const mocks = [createLogoutMutationResponse(mockConfig)];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                mutationResult = await result.current.logoutMutation();
+            });
+
+            expect(mutationResult.data).toEqual(expectedData);
+        });
+
+        it('handles logout errors', async () => {
+            const mocks = [
+                createLogoutMutationResponse({
+                    gqlError: new Error('Logout failed')
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            await act(async () => {
+                await expect(result.current.logoutMutation()).rejects.toThrow('Logout failed');
+            });
+
+            expect(result.current.logoutError).toBeDefined();
+        });
+    });
+
+    describe('logoutAllDevicesMutation', () => {
+        it.each([
+            [
+                'logs out all devices successfully',
+                { success: true },
+                {
+                    logoutAllDevicesMutation: {
+                        __typename: 'LogoutAllDevicesMutationPayload',
+                        success: true,
+                        errors: []
+                    }
+                }
+            ],
+            [
+                'handles logout all devices failure',
+                { success: false },
+                {
+                    logoutAllDevicesMutation: {
+                        __typename: 'LogoutAllDevicesMutationPayload',
+                        success: false,
+                        errors: []
+                    }
+                }
+            ]
+        ])('%s', async (_, mockConfig, expectedData) => {
+            const mocks = [createLogoutAllDevicesMutationResponse(mockConfig)];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                mutationResult = await result.current.logoutAllDevicesMutation();
+            });
+
+            expect(mutationResult.data).toEqual(expectedData);
+        });
+
+        it('handles logout all devices errors', async () => {
+            const mocks = [
+                createLogoutAllDevicesMutationResponse({
+                    gqlError: new Error('Network error')
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            await act(async () => {
+                await expect(result.current.logoutAllDevicesMutation()).rejects.toThrow('Network error');
+            });
+
+            expect(result.current.logoutAllError).toBeDefined();
+        });
+    });
+
+    describe('loading states', () => {
+        it('shows loading state during login', async () => {
+            const mocks = [
+                createLoginMutationResponse({
+                    googleToken: 'token',
+                    delay: 100
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            act(() => {
+                result.current.loginMutation({
+                    variables: {
+                        input: {
+                            googleToken: 'token',
+                            clientType: 'WEB'
+                        }
+                    }
+                });
+            });
+
+            expect(result.current.loginLoading).toBe(true);
+            expect(result.current.isLoading).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.loginLoading).toBe(false);
+                expect(result.current.isLoading).toBe(false);
+            });
+        });
+
+        it('shows loading state during refresh', async () => {
+            const mocks = [
+                createRefreshTokenMutationResponse({
+                    delay: 100
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            act(() => {
+                result.current.refreshTokenMutation();
+            });
+
+            expect(result.current.refreshLoading).toBe(true);
+            expect(result.current.isLoading).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.refreshLoading).toBe(false);
+                expect(result.current.isLoading).toBe(false);
+            });
+        });
+
+        it('shows loading state during logout', async () => {
+            const mocks = [
+                createLogoutMutationResponse({
+                    delay: 100
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            act(() => {
+                result.current.logoutMutation();
+            });
+
+            expect(result.current.logoutLoading).toBe(true);
+            expect(result.current.isLoading).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.logoutLoading).toBe(false);
+                expect(result.current.isLoading).toBe(false);
+            });
+        });
+
+        it('shows loading state during logout all devices', async () => {
+            const mocks = [
+                createLogoutAllDevicesMutationResponse({
+                    delay: 100
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            act(() => {
+                result.current.logoutAllDevicesMutation();
+            });
+
+            expect(result.current.logoutAllLoading).toBe(true);
+            expect(result.current.isLoading).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.logoutAllLoading).toBe(false);
+                expect(result.current.isLoading).toBe(false);
+            });
+        });
+
+        it('correctly combines multiple loading states', async () => {
+            const mocks = [
+                createLoginMutationResponse({
+                    googleToken: 'token',
+                    delay: 100
+                }),
+                createRefreshTokenMutationResponse({
+                    delay: 100
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            // Start login
+            act(() => {
+                result.current.loginMutation({
+                    variables: {
+                        input: {
+                            googleToken: 'token',
+                            clientType: 'WEB'
+                        }
+                    }
+                });
+            });
+
+            expect(result.current.loginLoading).toBe(true);
+            expect(result.current.refreshLoading).toBe(false);
+            expect(result.current.isLoading).toBe(true);
+
+            // Start refresh while login is still loading
+            act(() => {
+                result.current.refreshTokenMutation();
+            });
+
+            expect(result.current.loginLoading).toBe(true);
+            expect(result.current.refreshLoading).toBe(true);
+            expect(result.current.isLoading).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.loginLoading).toBe(false);
+                expect(result.current.refreshLoading).toBe(false);
+                expect(result.current.isLoading).toBe(false);
+            });
+        });
+    });
+
+    describe('api errors', () => {
+        it('returns API errors from login mutation', async () => {
+            const apiErrors = [
+                {
+                    __typename: 'GenericApiError',
+                    code: 'INVALID_TOKEN',
+                    field: 'googleToken',
+                    message: 'Invalid Google token'
+                }
+            ];
+            const mocks = [
+                createLoginMutationResponse({
+                    googleToken: 'invalid-token',
+                    apiErrors
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                mutationResult = await result.current.loginMutation({
+                    variables: {
+                        input: {
+                            googleToken: 'invalid-token',
+                            clientType: 'WEB'
+                        }
+                    }
+                });
+            });
+
+            expect(mutationResult.data.googleOAuthLoginMutation.errors).toEqual(apiErrors);
+        });
+
+        it('returns API errors from refresh token mutation', async () => {
+            const apiErrors = [
+                { __typename: 'GenericApiError', code: 'TOKEN_EXPIRED', message: 'Refresh token has expired' }
+            ];
+            const mocks = [
+                createRefreshTokenMutationResponse({
+                    apiErrors
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                mutationResult = await result.current.refreshTokenMutation();
+            });
+
+            expect(mutationResult.data.refreshTokenMutation.errors).toEqual(apiErrors);
+        });
+    });
+
+    describe('null payload handling', () => {
+        it.each([
+            ['login', 'loginMutation', 'googleOAuthLoginMutation', createLoginMutationResponse],
+            ['refresh token', 'refreshTokenMutation', 'refreshTokenMutation', createRefreshTokenMutationResponse],
+            ['logout', 'logoutMutation', 'logoutMutation', createLogoutMutationResponse],
+            [
+                'logout all devices',
+                'logoutAllDevicesMutation',
+                'logoutAllDevicesMutation',
+                createLogoutAllDevicesMutationResponse
+            ]
+        ])('handles null payload for %s mutation', async (_, mutationName, mutationResponseKey, createResponse) => {
+            const mocks = [
+                createResponse({
+                    nullPayload: true,
+                    googleToken: mutationName === 'loginMutation' ? 'token' : undefined
+                })
+            ];
+            const { result } = renderHookWithProviders({ mocks });
+
+            let mutationResult;
+            await act(async () => {
+                if (mutationName === 'loginMutation') {
+                    mutationResult = await result.current[mutationName]({
+                        variables: {
+                            input: {
+                                googleToken: 'token',
+                                clientType: 'WEB'
+                            }
+                        }
+                    });
+                } else {
+                    mutationResult = await result.current[mutationName]();
+                }
+            });
+
+            expect(mutationResult.data[mutationResponseKey]).toBeNull();
+        });
+    });
+});

--- a/apps/web/src/hooks/useAuthMutations.ts
+++ b/apps/web/src/hooks/useAuthMutations.ts
@@ -1,0 +1,92 @@
+import { useMutation, gql } from '@apollo/client';
+
+// GraphQL Mutations
+export const LOGIN_MUTATION = gql`
+    mutation LoginMutation($input: GoogleOAuthLoginMutationInput!) {
+        googleOAuthLoginMutation(input: $input) {
+            accessToken
+            user {
+                id
+                email
+                name
+            }
+            errors {
+                code
+                field
+                message
+            }
+        }
+    }
+`;
+
+export const REFRESH_TOKEN_MUTATION = gql`
+    mutation RefreshTokenMutation {
+        refreshTokenMutation {
+            accessToken
+            errors {
+                code
+                message
+            }
+        }
+    }
+`;
+
+export const LOGOUT_MUTATION = gql`
+    mutation LogoutMutation {
+        logoutMutation {
+            success
+            errors {
+                code
+                message
+            }
+        }
+    }
+`;
+
+export const LOGOUT_ALL_DEVICES_MUTATION = gql`
+    mutation LogoutAllDevicesMutation {
+        logoutAllDevicesMutation {
+            success
+            errors {
+                code
+                message
+            }
+        }
+    }
+`;
+
+/**
+ * Hook for authentication mutations
+ * Provides login, logout, refresh token, and logout all devices functionality
+ */
+export const useAuthMutations = () => {
+    const [loginMutation, { loading: loginLoading, error: loginError }] = useMutation(LOGIN_MUTATION);
+    const [refreshTokenMutation, { loading: refreshLoading, error: refreshError }] =
+        useMutation(REFRESH_TOKEN_MUTATION);
+    const [logoutMutation, { loading: logoutLoading, error: logoutError }] = useMutation(LOGOUT_MUTATION);
+    const [logoutAllDevicesMutation, { loading: logoutAllLoading, error: logoutAllError }] =
+        useMutation(LOGOUT_ALL_DEVICES_MUTATION);
+
+    return {
+        // Mutations
+        loginMutation,
+        refreshTokenMutation,
+        logoutMutation,
+        logoutAllDevicesMutation,
+
+        // Loading states
+        loginLoading,
+        refreshLoading,
+        logoutLoading,
+        logoutAllLoading,
+
+        // Error states
+        loginError,
+        refreshError,
+        logoutError,
+        logoutAllError,
+
+        // Composite loading state
+        isLoading: loginLoading || refreshLoading || logoutLoading || logoutAllLoading
+    };
+};


### PR DESCRIPTION
This pull request introduces a new hook, `useAuthMutations`, in the `apps/web/src/hooks/useAuthMutations.ts` file to streamline authentication operations using GraphQL mutations. The hook encapsulates functionality for login, token refresh, logout, and logout across all devices, while providing loading and error states for each operation.

### New functionality for authentication:

* **GraphQL mutations added**:
  - [`LOGIN_MUTATION`](diffhunk://#diff-e804a20df53d0e2aee2ad6ff28f71dd486ab8f399222dc3f6d516a183e5a4aaaR1-R92): Supports Google OAuth login, using the new `accessToken` field instead of the deprecated `token`.
  - [`REFRESH_TOKEN_MUTATION`](diffhunk://#diff-e804a20df53d0e2aee2ad6ff28f71dd486ab8f399222dc3f6d516a183e5a4aaaR1-R92): Refreshes the authentication token and handles potential errors.
  - [`LOGOUT_MUTATION`](diffhunk://#diff-e804a20df53d0e2aee2ad6ff28f71dd486ab8f399222dc3f6d516a183e5a4aaaR1-R92): Logs out the user and provides success/error feedback.
  - [`LOGOUT_ALL_DEVICES_MUTATION`](diffhunk://#diff-e804a20df53d0e2aee2ad6ff28f71dd486ab8f399222dc3f6d516a183e5a4aaaR1-R92): Logs out the user from all devices with success/error feedback.

* **Custom hook `useAuthMutations`**:
  - Provides access to the above mutations along with their respective loading and error states.
  - Includes a composite `isLoading` state to indicate if any mutation is currently in progress.