### PR TITLE
Add utility module for encoding and decoding IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A Google OAuth client ID is required for authentication. Set the `GOOGLE_CLIENT_
 A MongoDB Atlas database is also required for the backend. Set the `DATABASE_URL` environment variable in the backend's
 `.env` file.
 
-See the individual app's `.env.example` files for more details on required environment variables.
+See the individual apps' `.env.example` files for more details on required environment variables.
 
 ## Features
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -6,19 +6,18 @@ GraphQL API for Life Event Logger app
 
 Built with:
 
-- GraphQL Yoga server
-- Prisma ORM for MongoDB Atlas database
-- Vercel serverless
-- TypeScript
-- graphql-codegen for generating GQL types based on schema
-- google-auth-library and jsonwebtoken for user authentication and session management
-- Husky, Prettier, ESLint for maintaining code standards
-- graphql-scalars for custom scalar types
-- zod for form validation and env var validation
-- npm for dependency management
-- Vitest for testing framework
-
-React App at https://github.com/nathanchica/life_event_logger
+- **GraphQL Yoga** server
+- **Prisma ORM** for MongoDB Atlas database
+- **Vercel** serverless
+- **TypeScript**
+- **graphql-codegen** for generating GQL types based on schema
+- **google-auth-library** and **jsonwebtoken** for user authentication and session management
+- **Sqids** for encoding and decoding IDs
+- **Husky**, **Prettier**, **ESLint** for maintaining code standards
+- **graphql-scalars** for custom scalar types
+- **zod** for form validation and env var validation
+- **npm** for dependency management
+- **Vitest** for testing framework
 
 ## Table of Contents
 
@@ -39,22 +38,15 @@ React App at https://github.com/nathanchica/life_event_logger
 - MongoDB Atlas account (for database)
 - Google OAuth credentials (for authentication)
 
-### Installation
+### Setup
 
-1. Clone the repository:
-
-```bash
-git clone https://github.com/nathanchica/life_event_logger_api.git
-cd life_event_logger_api
-```
-
-2. Install dependencies:
+1. Install dependencies:
 
 ```bash
 npm install
 ```
 
-3. Set up environment variables:
+2. Set up environment variables:
    Create a `.env` file in the root directory with the following variables:
 
 ```env
@@ -69,9 +61,11 @@ GOOGLE_CLIENT_ID="your-google-client-id"
 
 # Node environment
 NODE_ENV="development"
+
+See `.env.example` for other required variables.
 ```
 
-4. Generate Prisma client:
+3. Generate Prisma client (This is needed to generate Prisma models and types from the schema):
 
 ```bash
 npm run prisma:generate

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -25,6 +25,7 @@
                 "graphql-scalars": "^1.24.2",
                 "graphql-yoga": "^5.14.0",
                 "jsonwebtoken": "^9.0.2",
+                "sqids": "^0.3.0",
                 "tiny-invariant": "^1.3.3",
                 "zod": "^3.25.76"
             },
@@ -11351,6 +11352,12 @@
             "dependencies": {
                 "tslib": "^2.0.3"
             }
+        },
+        "node_modules/sqids": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/sqids/-/sqids-0.3.0.tgz",
+            "integrity": "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==",
+            "license": "MIT"
         },
         "node_modules/stackback": {
             "version": "0.0.2",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,6 +50,7 @@
         "graphql-scalars": "^1.24.2",
         "graphql-yoga": "^5.14.0",
         "jsonwebtoken": "^9.0.2",
+        "sqids": "^0.3.0",
         "tiny-invariant": "^1.3.3",
         "zod": "^3.25.76"
     },

--- a/apps/api/src/utils/__tests__/encoder.test.ts
+++ b/apps/api/src/utils/__tests__/encoder.test.ts
@@ -1,0 +1,255 @@
+import { GraphQLError } from 'graphql';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { IdEncoder, getIdEncoder, resetIdEncoder } from '../encoder.js';
+
+describe('IdEncoder', () => {
+    let encoder: IdEncoder;
+    const sampleObjectId = '507f1f77bcf86cd799439011';
+    const sampleObjectId2 = '507f191e810c19729de860ea';
+
+    beforeEach(() => {
+        resetIdEncoder();
+        encoder = new IdEncoder();
+    });
+
+    describe('encode', () => {
+        it('should encode a valid MongoDB ObjectId', () => {
+            const encoded = encoder.encode(sampleObjectId, 'user');
+
+            expect(encoded).toBeTruthy();
+            expect(encoded.length).toBeGreaterThanOrEqual(11);
+            expect(encoded).not.toBe(sampleObjectId);
+        });
+
+        it('should encode different IDs to different values', () => {
+            const encoded1 = encoder.encode(sampleObjectId, 'user');
+            const encoded2 = encoder.encode(sampleObjectId2, 'user');
+
+            expect(encoded1).not.toBe(encoded2);
+        });
+
+        it('should encode same ID consistently (deterministic)', () => {
+            const encoded1 = encoder.encode(sampleObjectId, 'user');
+            const encoded2 = encoder.encode(sampleObjectId, 'user');
+
+            expect(encoded1).toBe(encoded2);
+        });
+
+        it('should produce different encodings for different entity types', () => {
+            const userEncoded = encoder.encode(sampleObjectId, 'user');
+            const eventEncoded = encoder.encode(sampleObjectId, 'loggableEvent');
+            const labelEncoded = encoder.encode(sampleObjectId, 'eventLabel');
+
+            expect(userEncoded).not.toBe(eventEncoded);
+            expect(userEncoded).not.toBe(labelEncoded);
+            expect(eventEncoded).not.toBe(labelEncoded);
+        });
+
+        it('should throw GraphQLError for empty ID', () => {
+            expect(() => encoder.encode('', 'user')).toThrow(GraphQLError);
+            expect(() => encoder.encode('', 'user')).toThrow('Cannot encode empty ID');
+        });
+
+        it('should handle various valid MongoDB ObjectId formats', () => {
+            const validIds = [
+                '000000000000000000000000',
+                'ffffffffffffffffffffffff',
+                '123456789abcdef012345678',
+                'abcdef0123456789abcdef01'
+            ];
+
+            validIds.forEach((id) => {
+                expect(() => encoder.encode(id, 'user')).not.toThrow();
+            });
+        });
+
+        it('should throw GraphQLError for invalid ID', () => {
+            expect(() => encoder.encode('gggggggggggggggggggggggg', 'user')).toThrowError(
+                new GraphQLError('Failed to encode ID', {
+                    extensions: { code: 'INTERNAL_SERVER_ERROR' }
+                })
+            );
+        });
+    });
+
+    describe('decode', () => {
+        it('should decode back to original ID', () => {
+            const encoded = encoder.encode(sampleObjectId, 'user');
+            const decoded = encoder.decode(encoded, 'user');
+
+            expect(decoded).toBe(sampleObjectId);
+        });
+
+        it('should handle all entity types correctly', () => {
+            const types: Array<'user' | 'loggableEvent' | 'eventLabel'> = ['user', 'loggableEvent', 'eventLabel'];
+
+            types.forEach((type) => {
+                const encoded = encoder.encode(sampleObjectId, type);
+                const decoded = encoder.decode(encoded, type);
+                expect(decoded).toBe(sampleObjectId);
+            });
+        });
+
+        it('should throw GraphQLError for empty encoded ID', () => {
+            expect(() => encoder.decode('', 'user')).toThrow(GraphQLError);
+            expect(() => encoder.decode('', 'user')).toThrow('Cannot decode empty ID');
+        });
+
+        it('should throw error for invalid encoded format', () => {
+            const invalidIds = [
+                'short', // Too short
+                '1234567890', // Wrong alphabet
+                'invalid!@#$', // Invalid characters
+                '           ' // Spaces
+            ];
+
+            invalidIds.forEach((invalidId) => {
+                expect(() => encoder.decode(invalidId, 'user')).toThrow(GraphQLError);
+                expect(() => encoder.decode(invalidId, 'user')).toThrow('Invalid ID format');
+            });
+        });
+
+        it('should throw error when decoding with wrong entity type', () => {
+            const userEncoded = encoder.encode(sampleObjectId, 'user');
+
+            // Should throw because alphabet doesn't match
+            expect(() => encoder.decode(userEncoded, 'loggableEvent')).toThrow(GraphQLError);
+        });
+    });
+
+    describe('encodeBatch', () => {
+        it('should encode multiple IDs', () => {
+            const ids = [sampleObjectId, sampleObjectId2];
+            const encoded = encoder.encodeBatch(ids, 'user');
+
+            expect(encoded).toHaveLength(2);
+            expect(encoded[0]).not.toBe(ids[0]);
+            expect(encoded[1]).not.toBe(ids[1]);
+            expect(encoded[0]).not.toBe(encoded[1]);
+        });
+
+        it('should return empty array for empty input', () => {
+            expect(encoder.encodeBatch([], 'user')).toEqual([]);
+        });
+
+        it('should filter out empty IDs', () => {
+            const ids = [sampleObjectId, '', sampleObjectId2, ''];
+            const encoded = encoder.encodeBatch(ids, 'user');
+
+            expect(encoded).toHaveLength(2);
+        });
+    });
+
+    describe('decodeBatch', () => {
+        it('should decode multiple IDs', () => {
+            const ids = [sampleObjectId, sampleObjectId2];
+            const encoded = encoder.encodeBatch(ids, 'user');
+            const decoded = encoder.decodeBatch(encoded, 'user');
+
+            expect(decoded).toEqual(ids);
+        });
+
+        it('should return empty array for empty input', () => {
+            expect(encoder.decodeBatch([], 'user')).toEqual([]);
+        });
+
+        it('should filter out empty encoded IDs', () => {
+            const encoded1 = encoder.encode(sampleObjectId, 'user');
+            const encoded2 = encoder.encode(sampleObjectId2, 'user');
+            const encodedIds = [encoded1, '', encoded2, ''];
+
+            const decoded = encoder.decodeBatch(encodedIds, 'user');
+            expect(decoded).toHaveLength(2);
+            expect(decoded).toEqual([sampleObjectId, sampleObjectId2]);
+        });
+
+        it('should filter out invalid encoded IDs that decode to empty array', () => {
+            const encoded1 = encoder.encode(sampleObjectId, 'user');
+            const encoded2 = encoder.encode(sampleObjectId2, 'user');
+
+            // These are valid sqids format but will decode to empty array
+            // Using the minimum valid sqids that don't encode any numbers
+            const invalidButValidFormat = 'abcdefghijk'; // Valid alphabet but doesn't decode to numbers
+
+            const encodedIds = [encoded1, invalidButValidFormat, encoded2];
+
+            const decoded = encoder.decodeBatch(encodedIds, 'user');
+            expect(decoded).toHaveLength(2);
+            expect(decoded).toEqual([sampleObjectId, sampleObjectId2]);
+        });
+    });
+
+    describe('isEncodedId', () => {
+        it('should return true for encoded IDs', () => {
+            const encoded = encoder.encode(sampleObjectId, 'user');
+            expect(encoder.isEncodedId(encoded)).toBe(true);
+            expect(encoder.isEncodedId(encoded, 'user')).toBe(true);
+        });
+
+        it('should return false for non-encoded strings', () => {
+            expect(encoder.isEncodedId(sampleObjectId)).toBe(false);
+            expect(encoder.isEncodedId('regular-string')).toBe(false);
+            expect(encoder.isEncodedId('123')).toBe(false);
+        });
+
+        it('should return false for too short strings', () => {
+            expect(encoder.isEncodedId('short')).toBe(false);
+            expect(encoder.isEncodedId('1234567890')).toBe(false);
+        });
+
+        it('should validate against specific entity type alphabet', () => {
+            const userEncoded = encoder.encode(sampleObjectId, 'user');
+
+            expect(encoder.isEncodedId(userEncoded, 'user')).toBe(true);
+            // Different alphabet, so should be false
+            expect(encoder.isEncodedId(userEncoded, 'loggableEvent')).toBe(false);
+        });
+    });
+
+    describe('singleton behavior', () => {
+        it('should return same instance', () => {
+            const instance1 = getIdEncoder();
+            const instance2 = getIdEncoder();
+
+            expect(instance1).toBe(instance2);
+        });
+
+        it('should reset singleton with resetIdEncoder', () => {
+            const instance1 = getIdEncoder();
+            resetIdEncoder();
+            const instance2 = getIdEncoder();
+
+            expect(instance1).not.toBe(instance2);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle hex case differences in ObjectIds', () => {
+            const lowercaseId = '507f1f77bcf86cd799439011';
+            const uppercaseId = '507F1F77BCF86CD799439011';
+
+            const encoded1 = encoder.encode(lowercaseId, 'user');
+            const encoded2 = encoder.encode(uppercaseId, 'user');
+
+            // Verify they encode properly
+            expect(encoded1).toBeTruthy();
+            expect(encoded2).toBeTruthy();
+
+            // Decode back and verify case is preserved
+            const decoded1 = encoder.decode(encoded1, 'user');
+            const decoded2 = encoder.decode(encoded2, 'user');
+
+            expect(decoded1).toBe(lowercaseId);
+            expect(decoded2.toLowerCase()).toBe(uppercaseId.toLowerCase());
+        });
+
+        it('should handle ObjectIds with all same characters', () => {
+            const sameCharsId = '000000000000000000000000';
+            const encoded = encoder.encode(sameCharsId, 'user');
+            const decoded = encoder.decode(encoded, 'user');
+
+            expect(decoded).toBe(sameCharsId);
+        });
+    });
+});

--- a/apps/api/src/utils/encoder.ts
+++ b/apps/api/src/utils/encoder.ts
@@ -1,7 +1,11 @@
 import { GraphQLError } from 'graphql';
 import Sqids from 'sqids';
+import { z } from 'zod';
 
 export type EntityType = 'user' | 'loggableEvent' | 'eventLabel';
+
+// MongoDB ObjectId validation schema
+const objectIdSchema = z.string().regex(/^[0-9a-f]{24}$/i, 'Invalid MongoDB ObjectId format');
 
 /**
  * Pre-defined alphabets for each entity type
@@ -53,6 +57,14 @@ export class IdEncoder {
     encode(id: string, entityType: EntityType): string {
         if (!id) {
             throw new GraphQLError('Cannot encode empty ID', {
+                extensions: { code: 'BAD_REQUEST' }
+            });
+        }
+
+        // Validate ObjectId format
+        const validation = objectIdSchema.safeParse(id);
+        if (!validation.success) {
+            throw new GraphQLError('Invalid ID format', {
                 extensions: { code: 'BAD_REQUEST' }
             });
         }

--- a/apps/api/src/utils/encoder.ts
+++ b/apps/api/src/utils/encoder.ts
@@ -1,0 +1,214 @@
+import { GraphQLError } from 'graphql';
+import Sqids from 'sqids';
+
+export type EntityType = 'user' | 'loggableEvent' | 'eventLabel';
+
+/**
+ * Pre-defined alphabets for each entity type
+ * Using different alphabets adds a layer of obfuscation
+ * Hardcoded for faster cold starts on Vercel
+ *
+ * Note: These alphabets are safe to hardcode and don't need to be secrets:
+ * - They're formatting parameters, not cryptographic keys
+ * - Changing them would break existing ID decoding
+ * - Security comes from unpredictable database IDs, not the alphabet
+ * - Anyone with encoded IDs could reverse-engineer the alphabet anyway
+ */
+const ALPHABETS = {
+    user: 'k3G7QAe51FCsPW89uBOhIpwqjlDogSKZzMxnr2LTtV6bdaYmJvERHfNXy4cU',
+    loggableEvent: 'xnrLtV6bdaYmJvERHfNXy4cUk3G7QAe51FCsPW89uBOhIpwqjlDogSKZzM2',
+    eventLabel: 'uBOhIpwqjlDogSKZzMxnr2LTtV6bdaYmJvERHfNXy4cUk3G7QAe51FCsPW89'
+} as const;
+
+// Lazy-loaded Sqids instances to minimize cold start impact
+const sqidsCache = new Map<EntityType, Sqids>();
+
+/**
+ * Gets or creates a Sqids instance for the given entity type
+ * Cached within the request lifecycle
+ */
+function getSqids(entityType: EntityType): Sqids {
+    let sqids = sqidsCache.get(entityType);
+    if (!sqids) {
+        sqids = new Sqids({
+            alphabet: ALPHABETS[entityType],
+            minLength: 11 // Balanced between security and UX
+        });
+        sqidsCache.set(entityType, sqids);
+    }
+    return sqids;
+}
+
+/**
+ * Lightweight ID encoder using Sqids
+ * Optimized for Vercel serverless with minimal initialization overhead
+ */
+export class IdEncoder {
+    /**
+     * Encodes a database ID into a URL-safe string
+     * @param id - The database ID to encode (MongoDB ObjectId)
+     * @param entityType - The type of entity
+     * @returns Encoded ID string
+     */
+    encode(id: string, entityType: EntityType): string {
+        if (!id) {
+            throw new GraphQLError('Cannot encode empty ID', {
+                extensions: { code: 'BAD_REQUEST' }
+            });
+        }
+
+        try {
+            const numbers = this.idToNumbers(id);
+            return getSqids(entityType).encode(numbers);
+        } catch {
+            // Don't expose internal errors
+            throw new GraphQLError('Failed to encode ID', {
+                extensions: { code: 'INTERNAL_SERVER_ERROR' }
+            });
+        }
+    }
+
+    /**
+     * Decodes an encoded ID back to the original database ID
+     * @param encodedId - The encoded ID string
+     * @param entityType - The expected entity type
+     * @returns Original database ID
+     */
+    decode(encodedId: string, entityType: EntityType): string {
+        if (!encodedId) {
+            throw new GraphQLError('Cannot decode empty ID', {
+                extensions: { code: 'BAD_REQUEST' }
+            });
+        }
+
+        try {
+            const sqids = getSqids(entityType);
+            const numbers = sqids.decode(encodedId);
+
+            if (!numbers || numbers.length === 0) {
+                throw new GraphQLError('Invalid ID format', {
+                    extensions: { code: 'BAD_REQUEST' }
+                });
+            }
+
+            return this.numbersToId(numbers);
+        } catch (error) {
+            if (error instanceof GraphQLError) {
+                throw error;
+            }
+
+            throw new GraphQLError('Invalid ID format', {
+                extensions: { code: 'BAD_REQUEST' }
+            });
+        }
+    }
+
+    /**
+     * Encodes multiple IDs efficiently
+     * @param ids - Array of database IDs
+     * @param entityType - The type of entity
+     * @returns Array of encoded IDs
+     */
+    encodeBatch(ids: string[], entityType: EntityType): string[] {
+        if (!ids || ids.length === 0) {
+            return [];
+        }
+
+        // Use same Sqids instance for all IDs in batch
+        const sqids = getSqids(entityType);
+        return ids
+            .map((id) => {
+                if (!id) return '';
+                const numbers = this.idToNumbers(id);
+                return sqids.encode(numbers);
+            })
+            .filter(Boolean);
+    }
+
+    /**
+     * Decodes multiple IDs efficiently
+     * @param encodedIds - Array of encoded IDs
+     * @param entityType - The expected entity type
+     * @returns Array of original database IDs
+     */
+    decodeBatch(encodedIds: string[], entityType: EntityType): string[] {
+        if (!encodedIds || encodedIds.length === 0) {
+            return [];
+        }
+
+        // Use same Sqids instance for all IDs in batch
+        const sqids = getSqids(entityType);
+        return encodedIds
+            .map((encodedId) => {
+                if (!encodedId) return '';
+                const numbers = sqids.decode(encodedId);
+                if (!numbers || numbers.length === 0) return '';
+                return this.numbersToId(numbers);
+            })
+            .filter(Boolean);
+    }
+
+    /**
+     * Checks if a string looks like an encoded ID
+     * @param value - String to check
+     * @param entityType - Optional entity type for alphabet validation
+     * @returns boolean
+     */
+    isEncodedId(value: string, entityType?: EntityType): boolean {
+        if (!value || value.length < 11) {
+            return false;
+        }
+
+        if (entityType) {
+            const alphabet = ALPHABETS[entityType];
+            return value.split('').every((char) => alphabet.includes(char));
+        }
+
+        // Check against all alphabets
+        const allChars = new Set(Object.values(ALPHABETS).join(''));
+        return value.split('').every((char) => allChars.has(char));
+    }
+
+    /**
+     * Converts MongoDB ObjectId to numbers for Sqids
+     * Optimized for minimal memory allocation
+     */
+    private idToNumbers(id: string): number[] {
+        // MongoDB ObjectIds are 24 hex chars
+        // Split into 3 chunks of 8 chars (32 bits each)
+        // This fits safely in JavaScript numbers
+        return [parseInt(id.slice(0, 8), 16), parseInt(id.slice(8, 16), 16), parseInt(id.slice(16, 24), 16)];
+    }
+
+    /**
+     * Converts numbers back to MongoDB ObjectId
+     */
+    private numbersToId(numbers: number[]): string {
+        if (numbers.length !== 3) {
+            throw new Error('Invalid number array length');
+        }
+
+        // Convert each number back to 8-char hex string
+        return numbers.map((num) => num.toString(16).padStart(8, '0')).join('');
+    }
+}
+
+// Singleton instance - created once per cold start
+let instance: IdEncoder | null = null;
+
+/**
+ * Gets the singleton IdEncoder instance
+ * @returns IdEncoder instance
+ */
+export function getIdEncoder(): IdEncoder {
+    if (!instance) {
+        instance = new IdEncoder();
+    }
+    return instance;
+}
+
+// Export for testing
+export function resetIdEncoder(): void {
+    instance = null;
+    sqidsCache.clear();
+}


### PR DESCRIPTION
This pull request adds a new utility for encoding and decoding MongoDB ObjectIds to obfuscated, URL-safe IDs using the `sqids` library. It introduces a robust, type-safe encoder/decoder with per-entity-type alphabets, comprehensive tests, and updates the documentation and dependencies accordingly.

### ID Encoding/Decoding Utility

* Added `IdEncoder` class in `apps/api/src/utils/encoder.ts` that obfuscates MongoDB ObjectIds using the `sqids` library, with a unique alphabet per entity type (`user`, `loggableEvent`, `eventLabel`). Includes batch encode/decode, encoded ID detection, and robust error handling with `GraphQLError`. Also provides a singleton accessor and reset function for testing.
* Added a comprehensive test suite in `apps/api/src/utils/__tests__/encoder.test.ts` to cover encoding/decoding, error cases, batch operations, and singleton behavior.

### Dependency Management

* Added `sqids` as a dependency in `apps/api/package.json` and `apps/api/package-lock.json` to support the new encoding utility. [[1]](diffhunk://#diff-2c40985d6d91eed8ae85ec1c8e754a85984ee32e156a600d2b7a467423d7e338R53) [[2]](diffhunk://#diff-8bdff5e81408664f9451fdc27067468849d65b5665c94bd7e96ba2008fcd2a4bR28) [[3]](diffhunk://#diff-8bdff5e81408664f9451fdc27067468849d65b5665c94bd7e96ba2008fcd2a4bR11356-R11361)

### Documentation Updates

* Updated `apps/api/README.md` to mention `Sqids` as a core dependency, clarify setup steps, and reference `.env.example` for environment variables. Also improved formatting and section naming. [[1]](diffhunk://#diff-31a92f1c67f6af74712cadf88311a65463655d4ff829634f77dfa7434ef29dc2L9-R20) [[2]](diffhunk://#diff-31a92f1c67f6af74712cadf88311a65463655d4ff829634f77dfa7434ef29dc2L42-R49) [[3]](diffhunk://#diff-31a92f1c67f6af74712cadf88311a65463655d4ff829634f77dfa7434ef29dc2R64-R68)
* Fixed minor grammar in the main `README.md` for clarity.