### PR TITLE
Encode ObjectIDs returned to client

### DIFF
--- a/apps/api/src/auth/__mocks__/token.ts
+++ b/apps/api/src/auth/__mocks__/token.ts
@@ -1,5 +1,11 @@
 import { faker } from '@faker-js/faker';
-import { TokenPayload } from 'google-auth-library';
+import { OAuth2Client, TokenPayload } from 'google-auth-library';
+import { beforeEach } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+
+beforeEach(() => {
+    mockReset(oAuth2Client);
+});
 
 export const createMockGoogleTokenPayload = (overrides?: Partial<TokenPayload>): TokenPayload => {
     return {
@@ -13,3 +19,5 @@ export const createMockGoogleTokenPayload = (overrides?: Partial<TokenPayload>):
         ...overrides
     };
 };
+
+export const oAuth2Client = mockDeep<OAuth2Client>();

--- a/apps/api/src/directives/__tests__/auth.test.ts
+++ b/apps/api/src/directives/__tests__/auth.test.ts
@@ -1,72 +1,64 @@
 import { GraphQLError } from 'graphql';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { createMockContext } from '../../mocks/context.js';
 import prismaMock from '../../prisma/__mocks__/client.js';
 import { createMockEventLabel } from '../../schema/eventLabel/__mocks__/eventLabel.js';
 import { createMockLoggableEvent } from '../../schema/loggableEvent/__mocks__/loggableEvent.js';
 import { createMockUserWithRelations } from '../../schema/user/__mocks__/user.js';
-import { validateResourceOwnership } from '../auth.js';
+import { getIdEncoder } from '../../utils/encoder.js';
+import { validateResourceOwnership, processAuthDirectiveArgs, ResourceArgs } from '../auth.js';
+
+// Initialize encoder for use in tests
+const encoder = getIdEncoder();
 
 describe('validateResourceOwnership', () => {
-    let mockContext: ReturnType<typeof createMockContext>;
-
-    beforeEach(() => {
-        mockContext = createMockContext();
-    });
-
-    describe('Authentication checks', () => {
-        it('should throw UNAUTHORIZED error when user is not authenticated', async () => {
-            await expect(validateResourceOwnership(mockContext, 'loggableEvent', 'event-123')).rejects.toMatchObject({
-                message: 'User not authenticated',
-                extensions: { code: 'UNAUTHORIZED' }
-            });
-        });
-    });
-
     describe('LoggableEvent ownership validation', () => {
         it('should pass when user owns the loggableEvent', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
+            const mockUser = createMockUserWithRelations();
             const mockEvent = createMockLoggableEvent({
-                id: 'event-123',
-                userId: 'user-123'
+                userId: mockUser.id
             });
 
-            mockContext = createMockContext({ user: mockUser });
             prismaMock.loggableEvent.findUnique.mockResolvedValue(mockEvent);
 
             // should not throw
-            await expect(validateResourceOwnership(mockContext, 'loggableEvent', 'event-123')).resolves.toBeUndefined();
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'loggableEvent', mockEvent.id)
+            ).resolves.toBeUndefined();
 
-            // Verify correct database call
+            // Verify correct database call with decoded ID
             expect(prismaMock.loggableEvent.findUnique).toHaveBeenCalledWith({
-                where: { id: 'event-123' },
+                where: { id: mockEvent.id },
                 select: { userId: true }
             });
         });
 
         it('should throw NOT_FOUND error when loggableEvent does not exist', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
-            mockContext = createMockContext({ user: mockUser });
+            const mockUser = createMockUserWithRelations();
+            const mockEvent = createMockLoggableEvent();
+
             prismaMock.loggableEvent.findUnique.mockResolvedValue(null);
 
-            await expect(validateResourceOwnership(mockContext, 'loggableEvent', 'event-123')).rejects.toMatchObject({
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'loggableEvent', mockEvent.id)
+            ).rejects.toMatchObject({
                 message: 'loggableEvent not found',
                 extensions: { code: 'NOT_FOUND' }
             });
         });
 
         it('should throw FORBIDDEN error when user does not own the loggableEvent', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
+            const mockUser = createMockUserWithRelations();
+            const otherUser = createMockUserWithRelations();
             const mockEvent = createMockLoggableEvent({
-                id: 'event-456',
-                userId: 'other-user-456'
+                userId: otherUser.id
             });
 
-            mockContext = createMockContext({ user: mockUser });
             prismaMock.loggableEvent.findUnique.mockResolvedValue(mockEvent);
 
-            await expect(validateResourceOwnership(mockContext, 'loggableEvent', 'event-456')).rejects.toMatchObject({
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'loggableEvent', mockEvent.id)
+            ).rejects.toMatchObject({
                 message: 'You do not have permission to access this loggableEvent',
                 extensions: { code: 'FORBIDDEN' }
             });
@@ -75,47 +67,51 @@ describe('validateResourceOwnership', () => {
 
     describe('EventLabel ownership validation', () => {
         it('should pass when user owns the eventLabel', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
+            const mockUser = createMockUserWithRelations();
             const mockLabel = createMockEventLabel({
-                id: 'label-123',
-                userId: 'user-123'
+                userId: mockUser.id
             });
 
-            mockContext = createMockContext({ user: mockUser });
             prismaMock.eventLabel.findUnique.mockResolvedValue(mockLabel);
 
             // should not throw
-            await expect(validateResourceOwnership(mockContext, 'eventLabel', 'label-123')).resolves.toBeUndefined();
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'eventLabel', mockLabel.id)
+            ).resolves.toBeUndefined();
 
-            // Verify correct database call
+            // Verify correct database call with decoded ID
             expect(prismaMock.eventLabel.findUnique).toHaveBeenCalledWith({
-                where: { id: 'label-123' },
+                where: { id: mockLabel.id },
                 select: { userId: true }
             });
         });
 
         it('should throw NOT_FOUND error when eventLabel does not exist', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
-            mockContext = createMockContext({ user: mockUser });
+            const mockUser = createMockUserWithRelations();
+            const mockLabel = createMockEventLabel();
+
             prismaMock.eventLabel.findUnique.mockResolvedValue(null);
 
-            await expect(validateResourceOwnership(mockContext, 'eventLabel', 'label-123')).rejects.toMatchObject({
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'eventLabel', mockLabel.id)
+            ).rejects.toMatchObject({
                 message: 'eventLabel not found',
                 extensions: { code: 'NOT_FOUND' }
             });
         });
 
         it('should throw FORBIDDEN error when user does not own the eventLabel', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
+            const mockUser = createMockUserWithRelations();
+            const otherUser = createMockUserWithRelations();
             const mockLabel = createMockEventLabel({
-                id: 'label-456',
-                userId: 'other-user-456'
+                userId: otherUser.id
             });
 
-            mockContext = createMockContext({ user: mockUser });
             prismaMock.eventLabel.findUnique.mockResolvedValue(mockLabel);
 
-            await expect(validateResourceOwnership(mockContext, 'eventLabel', 'label-456')).rejects.toMatchObject({
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'eventLabel', mockLabel.id)
+            ).rejects.toMatchObject({
                 message: 'You do not have permission to access this eventLabel',
                 extensions: { code: 'FORBIDDEN' }
             });
@@ -124,13 +120,13 @@ describe('validateResourceOwnership', () => {
 
     describe('Error handling', () => {
         it('should throw INTERNAL_ERROR for unknown resource type', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
-            mockContext = createMockContext({ user: mockUser });
+            const mockUser = createMockUserWithRelations();
+            const mockEvent = createMockLoggableEvent();
 
             await expect(
                 // Forcing an error by passing an unknown resource type
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                validateResourceOwnership(mockContext, 'unknownResource' as any, 'resource-123')
+                validateResourceOwnership(mockUser, prismaMock, 'unknownResource' as any, mockEvent.id)
             ).rejects.toMatchObject({
                 message: 'Unknown resource type: unknownResource',
                 extensions: { code: 'INTERNAL_ERROR' }
@@ -138,8 +134,8 @@ describe('validateResourceOwnership', () => {
         });
 
         it('should log and throw normal Error for non-GraphQL errors', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
-            mockContext = createMockContext({ user: mockUser });
+            const mockUser = createMockUserWithRelations();
+            const mockEvent = createMockLoggableEvent();
 
             // Mock database failure
             const dbError = new Error('Database connection failed');
@@ -148,9 +144,9 @@ describe('validateResourceOwnership', () => {
             // Spy on console.error
             const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-            await expect(validateResourceOwnership(mockContext, 'loggableEvent', 'event-123')).rejects.toThrow(
-                'Failed to verify resource ownership'
-            );
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'loggableEvent', mockEvent.id)
+            ).rejects.toThrow('Failed to verify resource ownership');
 
             // Verify console.error was called with the original error
             expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to verify resource ownership:', dbError);
@@ -159,8 +155,8 @@ describe('validateResourceOwnership', () => {
         });
 
         it('should rethrow GraphQL errors without wrapping', async () => {
-            const mockUser = createMockUserWithRelations({ id: 'user-123' });
-            mockContext = createMockContext({ user: mockUser });
+            const mockUser = createMockUserWithRelations();
+            const mockLabel = createMockEventLabel();
 
             // Mock a GraphQL error from the database layer
             const graphqlError = new GraphQLError('Custom GraphQL error', {
@@ -168,10 +164,276 @@ describe('validateResourceOwnership', () => {
             });
             prismaMock.eventLabel.findUnique.mockRejectedValue(graphqlError);
 
-            await expect(validateResourceOwnership(mockContext, 'eventLabel', 'label-123')).rejects.toMatchObject({
+            await expect(
+                validateResourceOwnership(mockUser, prismaMock, 'eventLabel', mockLabel.id)
+            ).rejects.toMatchObject({
                 message: 'Custom GraphQL error',
                 extensions: { code: 'CUSTOM_ERROR' }
             });
+        });
+    });
+});
+
+describe('processAuthDirectiveArgs', () => {
+    describe('Resource type validation', () => {
+        it.each([
+            {
+                resourceType: 'loggableEvent',
+                createMock: () => createMockLoggableEvent(),
+                encodeType: 'loggableEvent' as const
+            },
+            {
+                resourceType: 'eventLabel',
+                createMock: () => createMockEventLabel(),
+                encodeType: 'eventLabel' as const
+            }
+        ])('should accept valid resource type "$resourceType"', ({ resourceType, createMock, encodeType }) => {
+            const mockResource = createMock();
+            const encodedId = encoder.encode(mockResource.id, encodeType);
+            const args = { id: encodedId };
+
+            const result = processAuthDirectiveArgs(resourceType, args);
+
+            expect(result).toEqual({
+                resourceType,
+                resourceId: mockResource.id
+            });
+        });
+
+        it.each([
+            {
+                scenario: 'unknown resource type',
+                resourceType: 'unknownResource',
+                expectedMessage: 'Unknown resource type: unknownResource'
+            },
+            {
+                scenario: 'empty resource type',
+                resourceType: '',
+                expectedMessage: 'Unknown resource type: '
+            }
+        ])('should throw INTERNAL_ERROR for $scenario', ({ resourceType, expectedMessage }) => {
+            const mockEvent = createMockLoggableEvent();
+            const encodedId = encoder.encode(mockEvent.id, 'loggableEvent');
+            const args = { id: encodedId };
+
+            expect(() => processAuthDirectiveArgs(resourceType, args)).toThrowError(
+                new GraphQLError(expectedMessage, {
+                    extensions: { code: 'INTERNAL_ERROR' }
+                })
+            );
+        });
+    });
+
+    describe('Resource ID extraction', () => {
+        it.each([
+            {
+                scenario: 'ID from args.id',
+                resourceType: 'loggableEvent' as const,
+                createMock: () => createMockLoggableEvent(),
+                buildArgs: (encodedId: string) => ({ id: encodedId })
+            },
+            {
+                scenario: 'ID from args.input.id',
+                resourceType: 'eventLabel' as const,
+                createMock: () => createMockEventLabel(),
+                buildArgs: (encodedId: string) => ({ input: { id: encodedId } })
+            }
+        ])('should extract $scenario', ({ resourceType, createMock, buildArgs }) => {
+            const mockResource = createMock();
+            const encodedId = encoder.encode(mockResource.id, resourceType);
+            const args = buildArgs(encodedId);
+
+            const result = processAuthDirectiveArgs(resourceType, args);
+
+            expect(result.resourceId).toBe(mockResource.id);
+        });
+
+        it('should prefer args.input.id over args.id when both present', () => {
+            const mockEvent1 = createMockLoggableEvent();
+            const mockEvent2 = createMockLoggableEvent();
+            const encodedId1 = encoder.encode(mockEvent1.id, 'loggableEvent');
+            const encodedId2 = encoder.encode(mockEvent2.id, 'loggableEvent');
+            const args = {
+                input: { id: encodedId1 },
+                id: encodedId2
+            };
+
+            const result = processAuthDirectiveArgs('loggableEvent', args);
+
+            expect(result.resourceId).toBe(mockEvent1.id);
+        });
+
+        it.each([
+            {
+                scenario: 'no ID is provided',
+                resourceType: 'loggableEvent',
+                args: {},
+                expectedMessage: 'Resource ID is required for loggableEvent ownership check'
+            },
+            {
+                scenario: 'ID is null',
+                resourceType: 'eventLabel',
+                args: { id: null },
+                expectedMessage: 'Resource ID is required for eventLabel ownership check'
+            },
+            {
+                scenario: 'input exists but ID is undefined',
+                resourceType: 'loggableEvent',
+                args: { input: {} },
+                expectedMessage: 'Resource ID is required for loggableEvent ownership check'
+            },
+            {
+                scenario: 'empty string ID is provided',
+                resourceType: 'eventLabel',
+                args: { id: '' },
+                expectedMessage: 'Resource ID is required for eventLabel ownership check'
+            }
+        ])('should throw VALIDATION_ERROR when $scenario', ({ resourceType, args, expectedMessage }) => {
+            expect(() => processAuthDirectiveArgs(resourceType, args as ResourceArgs)).toThrowError(
+                new GraphQLError(expectedMessage, {
+                    extensions: { code: 'VALIDATION_ERROR' }
+                })
+            );
+        });
+    });
+
+    describe('ID decoding', () => {
+        it('should decode loggableEvent ID correctly', () => {
+            const mockEvent = createMockLoggableEvent();
+            const encodedId = encoder.encode(mockEvent.id, 'loggableEvent');
+            const args = { id: encodedId };
+
+            const result = processAuthDirectiveArgs('loggableEvent', args);
+
+            expect(result.resourceId).toBe(mockEvent.id);
+            expect(result.resourceType).toBe('loggableEvent');
+        });
+
+        it('should decode eventLabel ID correctly', () => {
+            const mockLabel = createMockEventLabel();
+            const encodedId = encoder.encode(mockLabel.id, 'eventLabel');
+            const args = { id: encodedId };
+
+            const result = processAuthDirectiveArgs('eventLabel', args);
+
+            expect(result.resourceId).toBe(mockLabel.id);
+            expect(result.resourceType).toBe('eventLabel');
+        });
+
+        it('should throw error for invalid encoded ID format', () => {
+            const args = { id: 'not-a-valid-encoded-id' };
+
+            expect(() => processAuthDirectiveArgs('loggableEvent', args)).toThrow();
+        });
+
+        it('should throw error when ID is encoded for wrong resource type', () => {
+            // Create a label and encode its ID as eventLabel type
+            const mockLabel = createMockEventLabel();
+            const encodedId = encoder.encode(mockLabel.id, 'eventLabel');
+            const args = { id: encodedId };
+
+            // But try to process it as a loggableEvent
+            expect(() => processAuthDirectiveArgs('loggableEvent', args)).toThrow();
+        });
+    });
+
+    describe('Integration scenarios', () => {
+        it.each([
+            {
+                scenario: 'typical update mutation args',
+                resourceType: 'loggableEvent' as const,
+                createMock: () => createMockLoggableEvent(),
+                buildArgs: (encodedId: string) => ({
+                    input: {
+                        id: encodedId,
+                        name: 'Updated Event',
+                        description: 'Updated description'
+                    }
+                })
+            },
+            {
+                scenario: 'typical delete mutation args',
+                resourceType: 'eventLabel' as const,
+                createMock: () => createMockEventLabel(),
+                buildArgs: (encodedId: string) => ({ id: encodedId })
+            },
+            {
+                scenario: 'query args structure',
+                resourceType: 'loggableEvent' as const,
+                createMock: () => createMockLoggableEvent(),
+                buildArgs: (encodedId: string) => ({ id: encodedId })
+            },
+            {
+                scenario: 'nested input with additional fields',
+                resourceType: 'eventLabel' as const,
+                createMock: () => createMockEventLabel(),
+                buildArgs: (encodedId: string) => ({
+                    input: {
+                        id: encodedId,
+                        name: 'New Name',
+                        color: '#FF0000',
+                        otherField: 'value'
+                    },
+                    someOtherArg: 'ignored'
+                })
+            }
+        ])('should handle $scenario', ({ resourceType, createMock, buildArgs }) => {
+            const mockResource = createMock();
+            const encodedId = encoder.encode(mockResource.id, resourceType);
+            const args = buildArgs(encodedId);
+
+            const result = processAuthDirectiveArgs(resourceType, args);
+
+            expect(result).toEqual({
+                resourceType,
+                resourceId: mockResource.id
+            });
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should handle when args.input is null but args.id exists', () => {
+            const mockEvent = createMockLoggableEvent();
+            const encodedId = encoder.encode(mockEvent.id, 'loggableEvent');
+            const args = {
+                input: null,
+                id: encodedId
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const result = processAuthDirectiveArgs('loggableEvent', args as any);
+
+            expect(result.resourceId).toBe(mockEvent.id);
+        });
+
+        it('should handle when args.input.id is empty string', () => {
+            const args = {
+                input: { id: '' }
+            };
+
+            expect(() => processAuthDirectiveArgs('eventLabel', args)).toThrowError(
+                new GraphQLError('Resource ID is required for eventLabel ownership check', {
+                    extensions: { code: 'VALIDATION_ERROR' }
+                })
+            );
+        });
+
+        it('should handle multiple mock events with different IDs', () => {
+            const mockEvent1 = createMockLoggableEvent();
+            const mockEvent2 = createMockLoggableEvent();
+
+            // Ensure mock factory creates different IDs
+            expect(mockEvent1.id).not.toBe(mockEvent2.id);
+
+            const encodedId1 = encoder.encode(mockEvent1.id, 'loggableEvent');
+            const encodedId2 = encoder.encode(mockEvent2.id, 'loggableEvent');
+
+            const result1 = processAuthDirectiveArgs('loggableEvent', { id: encodedId1 });
+            const result2 = processAuthDirectiveArgs('loggableEvent', { id: encodedId2 });
+
+            expect(result1.resourceId).toBe(mockEvent1.id);
+            expect(result2.resourceId).toBe(mockEvent2.id);
+            expect(result1.resourceId).not.toBe(result2.resourceId);
         });
     });
 });

--- a/apps/api/src/mocks/context.ts
+++ b/apps/api/src/mocks/context.ts
@@ -1,10 +1,5 @@
-import { PrismaClient } from '@prisma/client';
-import { DeepMockProxy } from 'vitest-mock-extended';
-
 import { GraphQLContext } from '../context.js';
 import prismaMock from '../prisma/__mocks__/client.js';
-
-export type MockPrismaClient = DeepMockProxy<PrismaClient>;
 
 export const createMockContext = (overrides?: Partial<GraphQLContext>): GraphQLContext => {
     // Create default mock request if not provided
@@ -32,6 +27,8 @@ export const createMockContext = (overrides?: Partial<GraphQLContext>): GraphQLC
         },
         response: defaultResponse,
         cookies: {},
+        params: {},
+        waitUntil: () => {},
         ...overrides
     };
 };

--- a/apps/api/src/schema/eventLabel/__mocks__/eventLabel.ts
+++ b/apps/api/src/schema/eventLabel/__mocks__/eventLabel.ts
@@ -3,9 +3,9 @@ import { EventLabel } from '@prisma/client';
 
 export const createMockEventLabel = (overrides?: Partial<EventLabel>): EventLabel => {
     return {
-        id: faker.string.uuid(),
+        id: faker.database.mongodbObjectId(),
         name: faker.word.noun({ length: { min: 3, max: 20 } }),
-        userId: faker.string.uuid(),
+        userId: faker.database.mongodbObjectId(),
         createdAt: faker.date.past(),
         updatedAt: faker.date.recent(),
         loggableEventIds: [],

--- a/apps/api/src/schema/loggableEvent/__mocks__/loggableEvent.ts
+++ b/apps/api/src/schema/loggableEvent/__mocks__/loggableEvent.ts
@@ -2,14 +2,15 @@ import { faker } from '@faker-js/faker';
 import { LoggableEvent } from '@prisma/client';
 
 import { EventLabelParent } from '../../eventLabel';
+import { LoggableEventParent } from '../index.js';
 
 export const createMockLoggableEvent = (overrides?: Partial<LoggableEvent>): LoggableEvent => {
     return {
-        id: faker.string.uuid(),
+        id: faker.database.mongodbObjectId(),
         name: faker.word.noun({ length: { min: 3, max: 20 } }),
         timestamps: [],
         warningThresholdInDays: faker.number.int({ min: 1, max: 365 }),
-        userId: faker.string.uuid(),
+        userId: faker.database.mongodbObjectId(),
         labelIds: [],
         createdAt: faker.date.past(),
         updatedAt: faker.date.recent(),
@@ -19,7 +20,7 @@ export const createMockLoggableEvent = (overrides?: Partial<LoggableEvent>): Log
 
 export const createMockLoggableEventWithLabels = (
     overrides?: Partial<LoggableEvent> & { labels?: EventLabelParent[] }
-) => {
+): LoggableEventParent => {
     const { labels, ...eventOverrides } = overrides || {};
     const event = createMockLoggableEvent(eventOverrides);
     return {

--- a/apps/api/src/schema/loggableEvent/index.ts
+++ b/apps/api/src/schema/loggableEvent/index.ts
@@ -4,7 +4,9 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import { Resolvers } from '../../generated/graphql.js';
+import { getIdEncoder } from '../../utils/encoder.js';
 import { formatZodError } from '../../utils/validation.js';
+import { EventLabelParent } from '../eventLabel/index.js';
 import { UserParent } from '../user/index.js';
 
 export const MAX_EVENT_NAME_LENGTH = 25;
@@ -17,9 +19,10 @@ export type LoggableEventParent = {
     user?: UserParent;
     createdAt?: Date;
     updatedAt?: Date;
+    labels?: Array<EventLabelParent>;
 };
 
-const CreateLoggableEventSchema = z.object({
+export const CreateLoggableEventSchema = z.object({
     name: z
         .string()
         .min(1, 'Name cannot be empty')
@@ -28,7 +31,7 @@ const CreateLoggableEventSchema = z.object({
     labelIds: z.array(z.string()).optional()
 });
 
-const UpdateLoggableEventSchema = z.object({
+export const UpdateLoggableEventSchema = z.object({
     id: z.string().min(1, 'ID is required'),
     name: z
         .string()
@@ -40,12 +43,14 @@ const UpdateLoggableEventSchema = z.object({
     labelIds: z.array(z.string()).optional()
 });
 
+export type UpdateLoggableEventInput = z.infer<typeof UpdateLoggableEventSchema>;
+
 /**
  * Processes an array of timestamps by removing duplicates and sorting newest first
  * @param timestamps - Array of Date objects to process
  * @returns Deduplicated and sorted array of Date objects (newest first)
  */
-const processTimestamps = (timestamps: Date[]): Date[] => {
+export const processTimestamps = (timestamps: Date[]): Date[] => {
     const uniqueTimestamps = Array.from(new Set(timestamps.map((timestamp) => new Date(timestamp).getTime()))).map(
         (time) => new Date(time)
     );
@@ -119,30 +124,42 @@ const validateLabelOwnership = async ({
     }
 };
 
-const updateLoggableEventHelper = async ({
-    eventId,
-    updateData,
-    prisma
-}: {
-    eventId: string;
-    updateData: Prisma.LoggableEventUpdateInput;
-    prisma: PrismaClient;
-}) => {
-    // Process timestamps if they are being updated
-    if (updateData.timestamps && Array.isArray(updateData.timestamps)) {
-        updateData.timestamps = { set: processTimestamps(updateData.timestamps as Date[]) };
-    }
-
-    const event = await prisma.loggableEvent.update({
-        where: { id: eventId },
-        data: updateData,
-        include: { labels: true }
-    });
+/**
+ * Builds object from processed input to be used for updateLoggableEventHelper
+ */
+export const buildPrismaUpdateData = (processedInput: UpdateLoggableEventInput): Prisma.LoggableEventUpdateInput => {
+    const { name, warningThresholdInDays, timestamps, labelIds } = processedInput;
 
     return {
-        loggableEvent: event,
-        errors: []
+        ...(name ? { name } : {}),
+        ...(warningThresholdInDays !== undefined ? { warningThresholdInDays } : {}),
+        ...(timestamps !== undefined ? { timestamps: { set: processTimestamps(timestamps) } } : {}),
+        ...(labelIds !== undefined
+            ? {
+                  labels: {
+                      set: labelIds.map((id) => ({ id }))
+                  }
+              }
+            : {})
     };
+};
+
+/**
+ * Processes user input for updating a loggable event by validating input and decoding IDs
+ */
+export const processUpdateLoggableEventInput = (input: UpdateLoggableEventInput): UpdateLoggableEventInput => {
+    let processedInput: UpdateLoggableEventInput = { ...input };
+
+    const encoder = getIdEncoder();
+    const decodedEventId = encoder.decode(input.id, 'loggableEvent');
+    processedInput.id = decodedEventId;
+
+    if (input.labelIds && input.labelIds.length > 0) {
+        const decodedLabelIds = encoder.decodeBatch(input.labelIds, 'eventLabel');
+        processedInput.labelIds = decodedLabelIds;
+    }
+
+    return processedInput;
 };
 
 const resolvers: Resolvers = {
@@ -169,10 +186,14 @@ const resolvers: Resolvers = {
                     };
                 }
 
-                // Validate labelIds ownership if provided
+                // Decode and validate labelIds ownership if provided
+                let decodedLabelIds: string[] | undefined;
                 if (validatedInput.labelIds && validatedInput.labelIds.length > 0) {
+                    const encoder = getIdEncoder();
+                    decodedLabelIds = encoder.decodeBatch(validatedInput.labelIds, 'eventLabel');
+
                     await validateLabelOwnership({
-                        labelIds: validatedInput.labelIds,
+                        labelIds: decodedLabelIds,
                         userId: user.id,
                         prisma
                     });
@@ -184,9 +205,9 @@ const resolvers: Resolvers = {
                         warningThresholdInDays: validatedInput.warningThresholdInDays,
                         userId: user.id,
                         timestamps: [],
-                        labels: validatedInput.labelIds
+                        labels: decodedLabelIds
                             ? {
-                                  connect: validatedInput.labelIds.map((id) => ({ id }))
+                                  connect: decodedLabelIds.map((id) => ({ id }))
                               }
                             : undefined
                     },
@@ -225,13 +246,15 @@ const resolvers: Resolvers = {
 
                 invariant(user, 'User should exist after @requireOwner directive validation');
 
+                const processedInput = processUpdateLoggableEventInput(validatedInput);
+
                 // Check if name already exists for this user (excluding current event)
-                if (validatedInput.name) {
+                if (processedInput.name) {
                     const nameValidationError = await validateEventNameUniqueness({
-                        name: validatedInput.name,
+                        name: processedInput.name,
                         userId: user.id,
                         prisma,
-                        excludeEventId: validatedInput.id
+                        excludeEventId: processedInput.id
                     });
 
                     if (nameValidationError) {
@@ -243,34 +266,24 @@ const resolvers: Resolvers = {
                 }
 
                 // Validate labelIds ownership if provided
-                if (validatedInput.labelIds && validatedInput.labelIds.length > 0) {
+                if (processedInput.labelIds && processedInput.labelIds.length > 0) {
                     await validateLabelOwnership({
-                        labelIds: validatedInput.labelIds,
+                        labelIds: processedInput.labelIds,
                         userId: user.id,
                         prisma
                     });
                 }
 
-                const updateData = {
-                    ...(validatedInput.name ? { name: validatedInput.name } : {}),
-                    ...(validatedInput.warningThresholdInDays !== undefined
-                        ? { warningThresholdInDays: validatedInput.warningThresholdInDays }
-                        : {}),
-                    ...(validatedInput.timestamps !== undefined ? { timestamps: validatedInput.timestamps } : {}),
-                    ...(validatedInput.labelIds !== undefined
-                        ? {
-                              labels: {
-                                  set: validatedInput.labelIds.map((id) => ({ id }))
-                              }
-                          }
-                        : {})
-                };
-
-                return await updateLoggableEventHelper({
-                    eventId: validatedInput.id,
-                    updateData,
-                    prisma
+                const event = await prisma.loggableEvent.update({
+                    where: { id: processedInput.id },
+                    data: buildPrismaUpdateData(processedInput),
+                    include: { labels: true }
                 });
+
+                return {
+                    loggableEvent: event,
+                    errors: []
+                };
             } catch (error) {
                 if (error instanceof z.ZodError) {
                     return {
@@ -288,9 +301,13 @@ const resolvers: Resolvers = {
         deleteLoggableEvent: async (_, { input }, { prisma }) => {
             // Auth and ownership checks handled by @requireOwner directive
             try {
+                // Decode the event ID
+                const encoder = getIdEncoder();
+                const decodedEventId = encoder.decode(input.id, 'loggableEvent');
+
                 // @requireOwner directive already validated the event exists and user owns it
                 const event = await prisma.loggableEvent.delete({
-                    where: { id: input.id },
+                    where: { id: decodedEventId },
                     include: { labels: true }
                 });
 
@@ -308,23 +325,32 @@ const resolvers: Resolvers = {
         addTimestampToEvent: async (_, { input }, { prisma }) => {
             // Auth and ownership checks handled by @requireOwner directive
             try {
+                // Decode the event ID
+                const encoder = getIdEncoder();
+                const decodedEventId = encoder.decode(input.id, 'loggableEvent');
+
                 // Get the current event to retrieve existing timestamps
                 // Auth directive already validated the event exists and user owns it
                 const currentEvent = await prisma.loggableEvent.findUnique({
-                    where: { id: input.id },
+                    where: { id: decodedEventId },
                     select: { timestamps: true }
                 });
 
                 invariant(currentEvent, 'Event should exist after auth directive validation');
 
-                // Add the new timestamp to existing ones
-                const updatedTimestamps = [...currentEvent.timestamps, new Date(input.timestamp)];
-
-                return await updateLoggableEventHelper({
-                    eventId: input.id,
-                    updateData: { timestamps: updatedTimestamps },
-                    prisma
+                const event = await prisma.loggableEvent.update({
+                    where: { id: decodedEventId },
+                    data: buildPrismaUpdateData({
+                        id: decodedEventId,
+                        timestamps: [...currentEvent.timestamps, new Date(input.timestamp)]
+                    }),
+                    include: { labels: true }
                 });
+
+                return {
+                    loggableEvent: event,
+                    errors: []
+                };
             } catch (error) {
                 // Log the actual error for debugging (will appear in Vercel logs)
                 console.error('Error in addTimestampToEvent:', error);
@@ -335,10 +361,14 @@ const resolvers: Resolvers = {
         removeTimestampFromEvent: async (_, { input }, { prisma }) => {
             // Auth and ownership checks handled by @requireOwner directive
             try {
+                // Decode the event ID
+                const encoder = getIdEncoder();
+                const decodedEventId = encoder.decode(input.id, 'loggableEvent');
+
                 // Get the current event to retrieve existing timestamps
                 // Auth directive already validated the event exists and user owns it
                 const currentEvent = await prisma.loggableEvent.findUnique({
-                    where: { id: input.id },
+                    where: { id: decodedEventId },
                     select: { timestamps: true }
                 });
 
@@ -362,11 +392,19 @@ const resolvers: Resolvers = {
                     (timestamp: Date) => timestamp.getTime() !== timestampToRemove
                 );
 
-                return await updateLoggableEventHelper({
-                    eventId: input.id,
-                    updateData: { timestamps: updatedTimestamps },
-                    prisma
+                const event = await prisma.loggableEvent.update({
+                    where: { id: decodedEventId },
+                    data: buildPrismaUpdateData({
+                        id: decodedEventId,
+                        timestamps: updatedTimestamps
+                    }),
+                    include: { labels: true }
                 });
+
+                return {
+                    loggableEvent: event,
+                    errors: []
+                };
             } catch (error) {
                 // Log the actual error for debugging (will appear in Vercel logs)
                 console.error('Error in removeTimestampFromEvent:', error);
@@ -376,6 +414,10 @@ const resolvers: Resolvers = {
     },
 
     LoggableEvent: {
+        id: (parent) => {
+            const encoder = getIdEncoder();
+            return encoder.encode(parent.id, 'loggableEvent');
+        },
         user: async (parent, _, { prisma }) => {
             const user = await prisma.user.findUnique({
                 where: { id: parent.userId }

--- a/apps/api/src/schema/user/__mocks__/user.ts
+++ b/apps/api/src/schema/user/__mocks__/user.ts
@@ -1,9 +1,11 @@
 import { faker } from '@faker-js/faker';
 import { User } from '@prisma/client';
 
+import { UserParent } from '../index.js';
+
 export const createMockUser = (overrides?: Partial<User>): User => {
     return {
-        id: faker.string.uuid(),
+        id: faker.database.mongodbObjectId(),
         googleId: `google_${faker.string.alphanumeric(21)}`,
         email: faker.internet.email(),
         name: faker.person.fullName(),
@@ -13,7 +15,7 @@ export const createMockUser = (overrides?: Partial<User>): User => {
     };
 };
 
-export const createMockUserWithRelations = (overrides?: Partial<User>) => {
+export const createMockUserWithRelations = (overrides?: Partial<User>): UserParent => {
     return {
         ...createMockUser(overrides),
         loggableEvents: [],

--- a/apps/api/src/schema/user/index.ts
+++ b/apps/api/src/schema/user/index.ts
@@ -15,6 +15,7 @@ import {
 } from '../../auth/token.js';
 import { env } from '../../config/env.js';
 import { ClientType, Resolvers } from '../../generated/graphql.js';
+import { getIdEncoder } from '../../utils/encoder.js';
 import { formatZodError } from '../../utils/validation.js';
 import { EventLabelParent } from '../eventLabel/index.js';
 import { LoggableEventParent } from '../loggableEvent/index.js';
@@ -284,6 +285,10 @@ const resolvers: Resolvers = {
     },
 
     User: {
+        id: (parent) => {
+            const encoder = getIdEncoder();
+            return encoder.encode(parent.id, 'user');
+        },
         loggableEvents: async (parent, _, { prisma }) => {
             return prisma.loggableEvent.findMany({
                 where: { userId: parent.id },

--- a/apps/api/src/testSetup.ts
+++ b/apps/api/src/testSetup.ts
@@ -16,3 +16,11 @@ vi.mock('./prisma/client.js', async () => {
         prisma: prismaMock.default
     };
 });
+
+// Mock Google Auth Library
+vi.mock('google-auth-library', async () => {
+    const oAuth2ClientMock = (await import('./auth/__mocks__/token.js')).oAuth2Client;
+    return {
+        OAuth2Client: vi.fn().mockImplementation(() => oAuth2ClientMock)
+    };
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -16,16 +16,5 @@
         }
     },
     "include": ["src/**/*", "api/**/*"],
-    "exclude": [
-        "node_modules",
-        "dist",
-        ".vercel",
-        "coverage",
-        "**/__tests__/**/*",
-        "**/__mocks__/**/*",
-        "**/*.test.ts",
-        "**/*.spec.ts",
-        "src/testSetup.ts",
-        "src/mocks/**/*"
-    ]
+    "exclude": ["node_modules", "dist", ".vercel", "coverage", "**/*.spec.ts", "src/testSetup.ts"]
 }


### PR DESCRIPTION
- IDs returned to clients are now encoded
- IDs from clients are decoded before interacting with database
- Updated tests to use proper IDs
- Fixed types in tests and added test files to tsconfig
- Improved mocking for google oauth client