### PR TITLE
Create useMuiState hook and update eslint settings

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -83,16 +83,16 @@
     },
     "lint-staged": {
         "*.ts": [
-            "eslint --fix",
+            "eslint --fix --max-warnings=0",
             "prettier --write",
             "tsc-files --noEmit"
         ],
         "*.js": [
-            "eslint --fix",
+            "eslint --fix --max-warnings=0",
             "prettier --write"
         ],
         "*.graphql": [
-            "eslint --fix",
+            "eslint --fix --max-warnings=0",
             "prettier --write",
             "npm run codegen"
         ],

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -20,7 +20,8 @@ module.exports = {
                 node: true
             },
             rules: {
-                "react/prop-types": "off"
+                "react/prop-types": "off",
+                "react/display-name": "off"
             }
         }
     ],
@@ -30,9 +31,9 @@ module.exports = {
         'react/react-in-jsx-scope': 'off',
         'no-unused-vars': 'off',
         'react-hooks/exhaustive-deps': 'off',
-        '@typescript-eslint/no-unused-vars': ['error'],
+        '@typescript-eslint/no-unused-vars': ['warn'],
         'import/order': [
-            'error',
+            'warn',
             {
                 groups: ['builtin', 'external', 'internal', 'sibling', 'parent', 'index'],
                 'newlines-between': 'always',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -80,12 +80,12 @@
     "lint-staged": {
         "src/**/*.{ts,tsx}": [
             "prettier --write",
-            "eslint --fix",
+            "eslint --fix --max-warnings=0",
             "tsc-files --noEmit"
         ],
         "src/**/*.{js,jsx}": [
             "prettier --write",
-            "eslint --fix"
+            "eslint --fix --max-warnings=0"
         ],
         "src/**/*.{css,md,json}": [
             "prettier --write"

--- a/apps/web/src/hooks/__tests__/useMuiState.test.js
+++ b/apps/web/src/hooks/__tests__/useMuiState.test.js
@@ -1,0 +1,166 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { renderHook } from '@testing-library/react';
+
+import useMuiState from '../useMuiState';
+
+// Mock useMediaQuery
+jest.mock('@mui/material/useMediaQuery');
+
+describe('useMuiState', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const createWrapper = (themeOptions = {}) => {
+        const theme = createTheme(themeOptions);
+        return ({ children }) => <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+    };
+
+    describe('theme property', () => {
+        it('returns the current theme object', () => {
+            useMediaQuery.mockReturnValue(false);
+            const wrapper = createWrapper();
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.theme).toBeDefined();
+            expect(result.current.theme.palette).toBeDefined();
+            expect(result.current.theme.breakpoints).toBeDefined();
+        });
+
+        it('returns theme with custom palette when provided', () => {
+            useMediaQuery.mockReturnValue(false);
+            const customPalette = {
+                palette: {
+                    primary: {
+                        main: '#ff0000'
+                    }
+                }
+            };
+            const wrapper = createWrapper(customPalette);
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.theme.palette.primary.main).toBe('#ff0000');
+        });
+    });
+
+    describe('isMobile property', () => {
+        it.each([
+            ['returns true when screen is mobile size', true],
+            ['returns false when screen is not mobile size', false]
+        ])('%s', (_, isMobile) => {
+            useMediaQuery.mockReturnValue(isMobile);
+            const wrapper = createWrapper();
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.isMobile).toBe(isMobile);
+        });
+    });
+
+    describe('isDarkMode property', () => {
+        it.each([
+            ['returns true when theme mode is dark', 'dark', true],
+            ['returns false when theme mode is light', 'light', false],
+            ['returns false when theme mode is undefined', undefined, false]
+        ])('%s', (_, mode, expectedResult) => {
+            useMediaQuery.mockReturnValue(false);
+            const themeOptions = mode ? { palette: { mode } } : {};
+            const wrapper = createWrapper(themeOptions);
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.isDarkMode).toBe(expectedResult);
+        });
+    });
+
+    describe('hook return value', () => {
+        it('returns all three properties in a single object', () => {
+            useMediaQuery.mockReturnValue(true);
+            const wrapper = createWrapper({ palette: { mode: 'dark' } });
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current).toEqual({
+                theme: expect.objectContaining({
+                    palette: expect.objectContaining({ mode: 'dark' })
+                }),
+                isMobile: true,
+                isDarkMode: true
+            });
+        });
+
+        it('maintains stable references when theme does not change', () => {
+            useMediaQuery.mockReturnValue(false);
+            const wrapper = createWrapper();
+
+            const { result, rerender } = renderHook(() => useMuiState(), { wrapper });
+            const firstResult = result.current;
+
+            rerender();
+            const secondResult = result.current;
+
+            expect(firstResult.theme).toBe(secondResult.theme);
+        });
+    });
+
+    describe('responsive behavior', () => {
+        it('updates isMobile when media query changes', () => {
+            useMediaQuery.mockReturnValue(false);
+            const wrapper = createWrapper();
+
+            const { result, rerender } = renderHook(() => useMuiState(), { wrapper });
+            expect(result.current.isMobile).toBe(false);
+
+            // Simulate screen size change
+            useMediaQuery.mockReturnValue(true);
+            rerender();
+
+            expect(result.current.isMobile).toBe(true);
+        });
+    });
+
+    describe('integration scenarios', () => {
+        it('works correctly with light theme and desktop view', () => {
+            useMediaQuery.mockReturnValue(false);
+            const wrapper = createWrapper({ palette: { mode: 'light' } });
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.isDarkMode).toBe(false);
+            expect(result.current.isMobile).toBe(false);
+            expect(result.current.theme.palette.mode).toBe('light');
+        });
+
+        it('works correctly with dark theme and mobile view', () => {
+            useMediaQuery.mockReturnValue(true);
+            const wrapper = createWrapper({ palette: { mode: 'dark' } });
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.isDarkMode).toBe(true);
+            expect(result.current.isMobile).toBe(true);
+            expect(result.current.theme.palette.mode).toBe('dark');
+        });
+
+        it('handles custom theme with additional properties', () => {
+            useMediaQuery.mockReturnValue(false);
+            const customTheme = {
+                palette: {
+                    mode: 'light',
+                    custom: {
+                        specialColor: '#123456'
+                    }
+                }
+            };
+            const wrapper = createWrapper(customTheme);
+
+            const { result } = renderHook(() => useMuiState(), { wrapper });
+
+            expect(result.current.theme.palette.custom.specialColor).toBe('#123456');
+            expect(typeof result.current.theme.spacing).toBe('function');
+        });
+    });
+});

--- a/apps/web/src/hooks/useMuiState.ts
+++ b/apps/web/src/hooks/useMuiState.ts
@@ -1,0 +1,15 @@
+import { useTheme, Theme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+/**
+ * Custom hook for convenient access to MUI state and theme properties.
+ */
+const useMuiState = (): { theme: Theme; isMobile: boolean; isDarkMode: boolean } => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const isDarkMode = theme.palette.mode === 'dark';
+
+    return { theme, isMobile, isDarkMode };
+};
+
+export default useMuiState;


### PR DESCRIPTION
This pull request introduces a new custom hook for accessing Material-UI theme state in the web app, along with a comprehensive test suite to ensure its reliability. It also updates linting configurations to enforce stricter code quality standards during staged commits, and slightly relaxes some ESLint rules for the web app to reduce noise in development.

### New hook and tests

* Added `useMuiState` hook in `apps/web/src/hooks/useMuiState.ts` to provide convenient access to the current MUI theme, mobile screen detection, and dark mode status.
* Added a thorough test suite for `useMuiState` in `apps/web/src/hooks/__tests__/useMuiState.test.js`, covering theme properties, responsive behavior, integration scenarios, and reference stability.

### Linting configuration improvements

* Updated `lint-staged` commands in both `apps/api/package.json` and `apps/web/package.json` to use `eslint --fix --max-warnings=0`, causing lint-staged to fail if any warnings are present, thereby enforcing stricter code quality. [[1]](diffhunk://#diff-2c40985d6d91eed8ae85ec1c8e754a85984ee32e156a600d2b7a467423d7e338L86-R95) [[2]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L83-R88)

### ESLint rule adjustments (web app only)

* Changed `@typescript-eslint/no-unused-vars` and `import/order` rules from `'error'` to `'warn'` in `apps/web/.eslintrc.cjs` to reduce development friction by showing warnings instead of errors for unused variables and import order.