### PR TITLE
Mobile-friendly enhancements and refactors

### DIFF
--- a/apps/web/src/components/EventCards/CreateEventCard.tsx
+++ b/apps/web/src/components/EventCards/CreateEventCard.tsx
@@ -10,7 +10,7 @@ import { blue, grey } from '@mui/material/colors';
 import { visuallyHidden } from '@mui/utils';
 
 import EditEventCard from './EditEventCard';
-import { CARD_WIDTH } from './EventCard';
+import EventCardGridItem from './EventCardGridItem';
 
 /**
  * CreateEventCard component for displaying a card that allows users to create a new event.
@@ -29,39 +29,47 @@ const CreateEventCard = () => {
     return formIsShowing ? (
         <EditEventCard onDismiss={hideForm} />
     ) : (
-        <Box
-            css={css`
-                border-radius: 8px;
-                border: 1px dashed ${grey[400]};
-                color: ${grey[400]};
-
-                :hover {
-                    border-color: ${blue[400]};
-                    color: ${blue[400]};
-                }
-            `}
-        >
-            <ButtonBase
-                onClick={handleAddEventCardClick}
-                aria-label="Add event"
-                aria-describedby="create-event-help"
+        <EventCardGridItem>
+            <Box
                 css={css`
-                    width: ${CARD_WIDTH};
-                    height: 200px;
+                    border-radius: 8px;
+                    border: 1px dashed ${grey[400]};
+                    color: ${grey[400]};
+                    width: 100%;
+
+                    :hover {
+                        border-color: ${blue[400]};
+                        color: ${blue[400]};
+                    }
                 `}
             >
-                <Box
+                <ButtonBase
+                    onClick={handleAddEventCardClick}
+                    aria-label="Add event"
+                    aria-describedby="create-event-help"
                     css={css`
-                        margin: auto;
+                        width: 100%;
+                        height: 200px;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
                     `}
                 >
-                    <AddIcon color="inherit" aria-hidden="true" />
-                    <Box id="create-event-help" sx={visuallyHidden}>
-                        Click to create a new event
+                    <Box
+                        css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}
+                    >
+                        <AddIcon color="inherit" aria-hidden="true" />
+                        <Box id="create-event-help" sx={visuallyHidden}>
+                            Click to create a new event
+                        </Box>
                     </Box>
-                </Box>
-            </ButtonBase>
-        </Box>
+                </ButtonBase>
+            </Box>
+        </EventCardGridItem>
     );
 };
 

--- a/apps/web/src/components/EventCards/EditEventCard.tsx
+++ b/apps/web/src/components/EventCards/EditEventCard.tsx
@@ -16,7 +16,6 @@ import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { blueGrey } from '@mui/material/colors';
-import { useTheme } from '@mui/material/styles';
 import { visuallyHidden } from '@mui/utils';
 import invariant from 'tiny-invariant';
 
@@ -25,6 +24,7 @@ import EventLabelAutocomplete from './EventLabelAutocomplete';
 import WarningThresholdForm from './WarningThresholdForm';
 
 import { useLoggableEvents } from '../../hooks/useLoggableEvents';
+import useMuiState from '../../hooks/useMuiState';
 import { useAuth } from '../../providers/AuthProvider';
 import { useViewOptions } from '../../providers/ViewOptionsProvider';
 import { EventLabel, LoggableEvent } from '../../utils/types';
@@ -126,13 +126,12 @@ type Props = {
  */
 const EditEventCard = ({ onDismiss, eventIdToEdit }: Props) => {
     const { user } = useAuth();
-    const theme = useTheme();
+    const { isDarkMode } = useMuiState();
     const { createLoggableEvent, updateLoggableEvent } = useLoggableEvents();
     const { activeEventLabelId } = useViewOptions();
 
     invariant(user, 'User is not authenticated');
 
-    const isDarkMode = theme.palette.mode === 'dark';
     const isCreatingNewEvent = !eventIdToEdit;
 
     /**
@@ -280,16 +279,16 @@ const EditEventCard = ({ onDismiss, eventIdToEdit }: Props) => {
 
     return (
         <ClickAwayListener onClickAway={dismissForm} mouseEvent="onMouseDown" touchEvent="onTouchStart">
-            <Box
-                component="form"
-                onSubmit={eventIdToEdit ? handleUpdateEventSubmit : handleNewEventSubmit}
-                role="form"
-                aria-label={isCreatingNewEvent ? 'Create new event' : 'Edit event'}
+            <EventCard
+                css={css`
+                    background-color: ${isDarkMode ? blueGrey[900] : blueGrey[50]};
+                `}
             >
-                <EventCard
-                    css={css`
-                        background-color: ${isDarkMode ? blueGrey[900] : blueGrey[50]};
-                    `}
+                <Box
+                    component="form"
+                    onSubmit={eventIdToEdit ? handleUpdateEventSubmit : handleNewEventSubmit}
+                    role="form"
+                    aria-label={isCreatingNewEvent ? 'Create new event' : 'Edit event'}
                 >
                     <CardContent>
                         {/* Event name */}
@@ -388,8 +387,8 @@ const EditEventCard = ({ onDismiss, eventIdToEdit }: Props) => {
                             </Typography>
                         )}
                     </CardActions>
-                </EventCard>
-            </Box>
+                </Box>
+            </EventCard>
         </ClickAwayListener>
     );
 };

--- a/apps/web/src/components/EventCards/EventCard.tsx
+++ b/apps/web/src/components/EventCards/EventCard.tsx
@@ -5,28 +5,11 @@ import { ReactNode, ComponentProps } from 'react';
 import { css } from '@emotion/react';
 import Card from '@mui/material/Card';
 import Grow from '@mui/material/Grow';
-import Skeleton from '@mui/material/Skeleton';
 import { amber, grey } from '@mui/material/colors';
-import { useTheme } from '@mui/material/styles';
 
-export const CARD_WIDTH = '400px';
+import EventCardGridItem from './EventCardGridItem';
 
-/**
- * EventCardSkeleton component for displaying a shimmer effect while the event card data is loading.
- */
-export const EventCardSkeleton = () => {
-    return (
-        <Grow in>
-            <Skeleton
-                data-testid="event-card-shimmer"
-                variant="rectangular"
-                width={CARD_WIDTH}
-                height={200}
-                aria-label="Loading event card"
-            />
-        </Grow>
-    );
-};
+import useMuiState from '../../hooks/useMuiState';
 
 type Props = {
     children: ReactNode;
@@ -35,30 +18,32 @@ type Props = {
 /**
  * EventCard component for displaying a single event card.
  */
-const EventCard = (props: Props) => {
-    const theme = useTheme();
-    return (
-        <Grow in>
-            <Card
-                css={css`
-                    background-color: ${theme.palette.mode === 'dark' ? grey[800] : amber[50]};
-                    width: ${CARD_WIDTH};
-                    overflow: visible;
+const EventCard = ({ children, ...cardProps }: Props) => {
+    const { isDarkMode } = useMuiState();
 
-                    :hover {
-                        box-shadow:
-                            0px 2px 4px -1px rgb(0 0 0 / 20%),
-                            0px 4px 5px 0px rgb(0 0 0 / 14%),
-                            0px 1px 10px 0px rgb(0 0 0 / 12%);
-                    }
-                `}
-                role="article"
-                aria-label="Event card"
-                {...props}
-            >
-                {props.children}
-            </Card>
-        </Grow>
+    return (
+        <EventCardGridItem>
+            <Grow in>
+                <Card
+                    css={css`
+                        background-color: ${isDarkMode ? grey[800] : amber[50]};
+                        overflow: visible;
+
+                        :hover {
+                            box-shadow:
+                                0px 2px 4px -1px rgb(0 0 0 / 20%),
+                                0px 4px 5px 0px rgb(0 0 0 / 14%),
+                                0px 1px 10px 0px rgb(0 0 0 / 12%);
+                        }
+                    `}
+                    role="article"
+                    aria-label="Event card"
+                    {...cardProps}
+                >
+                    {children}
+                </Card>
+            </Grow>
+        </EventCardGridItem>
     );
 };
 

--- a/apps/web/src/components/EventCards/EventCardGridItem.tsx
+++ b/apps/web/src/components/EventCards/EventCardGridItem.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+import Grid from '@mui/material/Grid';
+
+export const DESKTOP_CARD_MAX_WIDTH = '400px';
+
+type Props = {
+    children: ReactNode;
+};
+
+/**
+ * EventCardGridItem component that provides a consistent Grid item wrapper for event cards.
+ */
+const EventCardGridItem = ({ children }: Props) => {
+    return (
+        <Grid role="listitem" size={{ xs: 12, sm: 6, md: 4, lg: 4 }} sx={{ maxWidth: DESKTOP_CARD_MAX_WIDTH }}>
+            {children}
+        </Grid>
+    );
+};
+
+export default EventCardGridItem;

--- a/apps/web/src/components/EventCards/EventCardLogActions.tsx
+++ b/apps/web/src/components/EventCards/EventCardLogActions.tsx
@@ -7,6 +7,7 @@ import { visuallyHidden } from '@mui/utils';
 import EventDatepicker from './EventDatepicker';
 
 import { useLoggableEvents } from '../../hooks/useLoggableEvents';
+import useMuiState from '../../hooks/useMuiState';
 import { useToggle } from '../../utils/useToggle';
 
 type Props = {
@@ -20,6 +21,8 @@ type Props = {
  * Includes buttons to log today's event and log a custom date, along with the date picker.
  */
 const EventCardLogActions = ({ eventId, daysSinceLastEvent, timestamps }: Props) => {
+    const { isMobile } = useMuiState();
+
     const { addTimestampToEvent, addTimestampIsLoading } = useLoggableEvents();
     const { value: datepickerIsShowing, setFalse: hideDatepicker, toggle: toggleDatepicker } = useToggle();
 
@@ -42,13 +45,20 @@ const EventCardLogActions = ({ eventId, daysSinceLastEvent, timestamps }: Props)
 
     return (
         <>
-            <Stack direction="row" spacing={2} role="group" aria-label="Event logging actions">
+            <Stack
+                direction={isMobile ? 'column' : 'row'}
+                spacing={isMobile ? 1.5 : 2}
+                role="group"
+                aria-label="Event logging actions"
+                sx={{ width: isMobile ? '100%' : 'auto' }}
+            >
                 <Button
                     size="small"
                     disabled={isLogTodayDisabled}
                     onClick={() => handleLogEventClick()}
                     variant="contained"
                     aria-describedby={daysSinceLastEvent === 0 ? `today-disabled-${eventId}` : undefined}
+                    fullWidth={isMobile}
                 >
                     Log Today
                 </Button>
@@ -67,6 +77,7 @@ const EventCardLogActions = ({ eventId, daysSinceLastEvent, timestamps }: Props)
                     selected={datepickerIsShowing}
                     aria-expanded={datepickerIsShowing}
                     aria-controls={datepickerIsShowing ? `datepicker-${eventId}` : undefined}
+                    sx={{ width: isMobile ? '100%' : 'auto' }}
                 >
                     Log custom date
                 </ToggleButton>

--- a/apps/web/src/components/EventCards/EventCardShimmer.tsx
+++ b/apps/web/src/components/EventCards/EventCardShimmer.tsx
@@ -1,0 +1,25 @@
+import Grow from '@mui/material/Grow';
+import Skeleton from '@mui/material/Skeleton';
+
+import EventCardGridItem, { DESKTOP_CARD_MAX_WIDTH } from './EventCardGridItem';
+
+/**
+ * EventCardShimmer component for displaying a shimmer effect while the event card data is loading.
+ */
+const EventCardShimmer = () => {
+    return (
+        <EventCardGridItem>
+            <Grow in>
+                <Skeleton
+                    data-testid="event-card-shimmer"
+                    variant="rectangular"
+                    width={DESKTOP_CARD_MAX_WIDTH}
+                    height={200}
+                    aria-label="Loading event card"
+                />
+            </Grow>
+        </EventCardGridItem>
+    );
+};
+
+export default EventCardShimmer;

--- a/apps/web/src/components/EventCards/LastEventDisplay.tsx
+++ b/apps/web/src/components/EventCards/LastEventDisplay.tsx
@@ -3,8 +3,8 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { orange, red } from '@mui/material/colors';
-import { useTheme } from '@mui/material/styles';
 
+import useMuiState from '../../hooks/useMuiState';
 import { DAYS_IN_YEAR, DAYS_IN_MONTH } from '../../utils/time';
 
 type Props = {
@@ -13,10 +13,9 @@ type Props = {
 };
 
 const LastEventDisplay = ({ daysSinceLastEvent, warningThresholdInDays }: Props) => {
-    const isViolatingThreshold = warningThresholdInDays > 0 && daysSinceLastEvent >= warningThresholdInDays;
+    const { isDarkMode } = useMuiState();
 
-    const theme = useTheme();
-    const isDarkMode = theme.palette.mode === 'dark';
+    const isViolatingThreshold = warningThresholdInDays > 0 && daysSinceLastEvent >= warningThresholdInDays;
 
     let textToDisplay;
     if (daysSinceLastEvent === 0) {

--- a/apps/web/src/components/EventCards/__tests__/EventCard.test.js
+++ b/apps/web/src/components/EventCards/__tests__/EventCard.test.js
@@ -1,7 +1,7 @@
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { render, screen } from '@testing-library/react';
 
-import EventCard, { EventCardSkeleton } from '../EventCard';
+import EventCard from '../EventCard';
 
 describe('EventCard', () => {
     it.each([['light'], ['dark']])('renders in %s mode', (themeMode) => {
@@ -21,24 +21,5 @@ describe('EventCard', () => {
 
         expect(screen.getByRole('article', { name: 'Event card' })).toBeInTheDocument();
         expect(screen.getByText('Test content')).toBeInTheDocument();
-    });
-});
-
-describe('EventCardSkeleton', () => {
-    it.each([['light'], ['dark']])('renders skeleton in %s mode', (themeMode) => {
-        const muiTheme = createTheme({
-            palette: {
-                mode: themeMode
-            }
-        });
-
-        render(
-            <ThemeProvider theme={muiTheme}>
-                <EventCardSkeleton />
-            </ThemeProvider>
-        );
-
-        expect(screen.getByTestId('event-card-shimmer')).toBeInTheDocument();
-        expect(screen.getByLabelText('Loading event card')).toBeInTheDocument();
     });
 });

--- a/apps/web/src/components/EventCards/__tests__/EventCardLogActions.test.js
+++ b/apps/web/src/components/EventCards/__tests__/EventCardLogActions.test.js
@@ -3,9 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { parseISO } from 'date-fns';
 
 import { useLoggableEvents } from '../../../hooks/useLoggableEvents';
+import useMuiState from '../../../hooks/useMuiState';
 import EventCardLogActions from '../EventCardLogActions';
 
 jest.mock('../../../hooks/useLoggableEvents');
+jest.mock('../../../hooks/useMuiState');
 jest.mock('../EventDatepicker', () => {
     return function MockEventDatepicker({ eventId, isShowing, onAccept }) {
         if (!isShowing) return null;
@@ -31,6 +33,9 @@ describe('EventCardLogActions', () => {
             addTimestampToEvent: mockAddTimestampToEvent,
             addTimestampIsLoading: false
         });
+        useMuiState.mockReturnValue({
+            isMobile: false
+        });
     });
 
     afterEach(() => {
@@ -44,7 +49,14 @@ describe('EventCardLogActions', () => {
         timestamps: [new Date('2025-01-09T10:00:00Z')]
     };
 
-    it('should render log today and log custom date buttons', () => {
+    it.each([
+        ['desktop view', false],
+        ['mobile view', true]
+    ])('should render log today and log custom date buttons in %s', (_, isMobile) => {
+        useMuiState.mockReturnValue({
+            isMobile
+        });
+
         render(<EventCardLogActions {...defaultProps} />);
 
         expect(screen.getByRole('button', { name: 'Log Today' })).toBeInTheDocument();

--- a/apps/web/src/components/EventCards/__tests__/EventCardShimmer.test.js
+++ b/apps/web/src/components/EventCards/__tests__/EventCardShimmer.test.js
@@ -1,0 +1,23 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+
+import EventCardShimmer from '../EventCardShimmer';
+
+describe('EventCardShimmer', () => {
+    it.each([['light'], ['dark']])('renders skeleton in %s mode', (themeMode) => {
+        const muiTheme = createTheme({
+            palette: {
+                mode: themeMode
+            }
+        });
+
+        render(
+            <ThemeProvider theme={muiTheme}>
+                <EventCardShimmer />
+            </ThemeProvider>
+        );
+
+        expect(screen.getByTestId('event-card-shimmer')).toBeInTheDocument();
+        expect(screen.getByLabelText('Loading event card')).toBeInTheDocument();
+    });
+});

--- a/apps/web/src/components/LoggableEventsList.tsx
+++ b/apps/web/src/components/LoggableEventsList.tsx
@@ -1,5 +1,4 @@
 import { gql, useFragment } from '@apollo/client';
-import Grid from '@mui/material/Grid';
 import invariant from 'tiny-invariant';
 
 import LoggableEventCard from './EventCards/LoggableEventCard';
@@ -56,11 +55,7 @@ const LoggableEventsList = () => {
     return (
         <>
             {filteredEventFragments.map(({ id, name }) => {
-                return (
-                    <Grid key={`event-${name}`} role="listitem">
-                        <LoggableEventCard eventId={id} />
-                    </Grid>
-                );
+                return <LoggableEventCard key={`event-${name}`} eventId={id} />;
             })}
         </>
     );

--- a/apps/web/src/components/LoggableEventsView.tsx
+++ b/apps/web/src/components/LoggableEventsView.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
+import { useEffect } from 'react';
+
 import { css } from '@emotion/react';
 import KeyboardDoubleArrowRight from '@mui/icons-material/KeyboardDoubleArrowRight';
 import Box from '@mui/material/Box';
@@ -9,13 +11,13 @@ import Paper from '@mui/material/Paper';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { blueGrey, green } from '@mui/material/colors';
-import { useTheme } from '@mui/material/styles';
 
 import CreateEventCard from './EventCards/CreateEventCard';
-import { EventCardSkeleton } from './EventCards/EventCard';
+import EventCardShimmer from './EventCards/EventCardShimmer';
 import LoggableEventsList from './LoggableEventsList';
 import Sidebar from './Sidebar';
 
+import useMuiState from '../hooks/useMuiState';
 import { useToggle } from '../utils/useToggle';
 
 type Props = {
@@ -29,19 +31,22 @@ type Props = {
  * It includes a sidebar for navigation and a loading state while data is being fetched.
  */
 const LoggableEventsView = ({ isLoading = false, isShowingFetchError = false }: Props) => {
-    const theme = useTheme();
-    const { value: sidebarIsCollapsed, setTrue: collapseSidebar, setFalse: expandSidebar } = useToggle(false);
+    const { theme, isMobile, isDarkMode } = useMuiState();
+    const { value: sidebarIsCollapsed, setTrue: collapseSidebar, setFalse: expandSidebar } = useToggle(isMobile);
 
-    const isDarkMode = theme.palette.mode === 'dark';
+    useEffect(() => {
+        if (isMobile) {
+            collapseSidebar();
+        } else {
+            expandSidebar();
+        }
+    }, [isMobile, collapseSidebar, expandSidebar]);
 
     const mainContent = (
         <Grid
             role="main"
             aria-label="Loggable events main content"
-            css={css`
-                padding: 64px;
-                overflow-y: scroll;
-            `}
+            sx={{ overflowY: 'scroll', padding: isMobile ? 4 : 8 }}
             size="grow"
         >
             <Grid container spacing={5} role="list" aria-label="List of loggable events" aria-live="polite">
@@ -62,21 +67,13 @@ const LoggableEventsView = ({ isLoading = false, isShowingFetchError = false }: 
                     </Grid>
                 ) : isLoading ? (
                     <>
-                        <Grid role="listitem">
-                            <EventCardSkeleton />
-                        </Grid>
-                        <Grid role="listitem">
-                            <EventCardSkeleton />
-                        </Grid>
-                        <Grid role="listitem">
-                            <EventCardSkeleton />
-                        </Grid>
+                        <EventCardShimmer />
+                        <EventCardShimmer />
+                        <EventCardShimmer />
                     </>
                 ) : (
                     <>
-                        <Grid role="listitem">
-                            <CreateEventCard />
-                        </Grid>
+                        <CreateEventCard />
                         <LoggableEventsList />
                     </>
                 )}
@@ -90,6 +87,10 @@ const LoggableEventsView = ({ isLoading = false, isShowingFetchError = false }: 
             css={css`
                 background-color: ${theme.palette.background.default};
                 position: relative;
+                min-height: 100vh;
+                min-height: 100dvh;
+                width: 100%;
+                overflow: hidden;
             `}
         >
             {sidebarIsCollapsed && (
@@ -124,8 +125,10 @@ const LoggableEventsView = ({ isLoading = false, isShowingFetchError = false }: 
                 role="application"
                 aria-label="Life event logger application"
                 css={css`
-                    height: 100vh;
-                    width: 100vw;
+                    height: 100%;
+                    min-height: 100vh;
+                    min-height: 100dvh;
+                    width: 100%;
                 `}
             >
                 <Grid size="auto">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import EventLabelList from './EventLabels/EventLabelList';
 import EventLabelShimmer from './EventLabels/EventLabelShimmer';
 
 import { useAuthMutations } from '../hooks/useAuthMutations';
+import useMuiState from '../hooks/useMuiState';
 import { useAuth } from '../providers/AuthProvider';
 import { useViewOptions } from '../providers/ViewOptionsProvider';
 import { useToggle } from '../utils/useToggle';
@@ -38,10 +39,11 @@ type Props = {
  * and a link to the GitHub repository.
  */
 const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
+    const { isMobile, isDarkMode } = useMuiState();
     const { value: isEditingLabels, setTrue: startEditingLabels, setFalse: stopEditingLabels } = useToggle(false);
     const { clearAuthData, isOfflineMode } = useAuth();
     const { logoutMutation } = useAuthMutations();
-    const { theme, enableDarkTheme, enableLightTheme } = useViewOptions();
+    const { enableDarkTheme, enableLightTheme } = useViewOptions();
 
     const handleLogout = async () => {
         if (!isOfflineMode) {
@@ -55,8 +57,7 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
         clearAuthData();
     };
 
-    const isDark = theme === 'dark';
-    const handleToggleTheme = () => (isDark ? enableLightTheme() : enableDarkTheme());
+    const handleToggleTheme = () => (isDarkMode ? enableLightTheme() : enableDarkTheme());
 
     const handleClickAway = () => {
         stopEditingLabels();
@@ -76,9 +77,10 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
                     elevation={3}
                     square
                     css={css`
-                        background-color: ${isDark ? blueGrey[900] : green[100]};
+                        background-color: ${isDarkMode ? blueGrey[900] : green[100]};
                         padding: 16px;
-                        width: 400px;
+                        padding-bottom: 80px;
+                        width: ${isMobile ? '100vw' : '400px'};
                         height: 100%;
                         position: relative;
                         display: flex;
@@ -99,7 +101,7 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
                                     aria-label="Hide sidebar"
                                     css={css`
                                         :hover {
-                                            background-color: ${isDark ? blueGrey[600] : green[200]};
+                                            background-color: ${isDarkMode ? blueGrey[600] : green[200]};
                                         }
                                     `}
                                 >
@@ -124,9 +126,8 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
                             <Box
                                 sx={{ mt: 4 }}
                                 css={css`
-                                    max-height: 80vh;
                                     overflow-y: auto;
-                                    width: 350px;
+                                    width: ${isMobile ? '250px' : '350px'};
                                 `}
                             >
                                 {isLoading ? (
@@ -145,19 +146,19 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
                     <Box
                         sx={{
                             position: 'absolute',
-                            left: 8,
+                            left: isCollapsed ? -999 : 8,
                             bottom: 16,
                             display: 'flex',
                             justifyContent: 'flex-start',
-                            width: '100%'
+                            zIndex: 1
                         }}
                     >
-                        <Tooltip title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
+                        <Tooltip title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}>
                             <IconButton
                                 onClick={handleToggleTheme}
-                                aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+                                aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
                             >
-                                {isDark ? <Brightness7Icon /> : <Brightness4Icon />}
+                                {isDarkMode ? <Brightness7Icon /> : <Brightness4Icon />}
                             </IconButton>
                         </Tooltip>
                         <Tooltip title={isEditingLabels ? 'Stop editing labels' : 'Manage labels'}>

--- a/apps/web/src/components/__tests__/LoggableEventsList.test.js
+++ b/apps/web/src/components/__tests__/LoggableEventsList.test.js
@@ -97,8 +97,8 @@ describe('LoggableEventsList', () => {
         it('shows all events when no activeEventLabelId is set', () => {
             renderWithProviders({ viewOptionsValue: { activeEventLabelId: null } });
 
-            const listItems = screen.getAllByRole('listitem');
-            expect(listItems).toHaveLength(3);
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(3);
 
             expect(screen.getByTestId('loggable-event-card-event-1')).toBeInTheDocument();
             expect(screen.getByTestId('loggable-event-card-event-2')).toBeInTheDocument();
@@ -112,19 +112,19 @@ describe('LoggableEventsList', () => {
         ])('filters events by %s', (_, activeEventLabelId, expectedEventIds) => {
             renderWithProviders({ viewOptionsValue: { activeEventLabelId } });
 
-            const listItems = screen.getAllByRole('listitem');
-            expect(listItems).toHaveLength(expectedEventIds.length);
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(expectedEventIds.length);
 
-            for (const eventId of expectedEventIds) {
+            expectedEventIds.forEach((eventId) => {
                 expect(screen.getByTestId(`loggable-event-card-${eventId}`)).toBeInTheDocument();
-            }
+            });
         });
 
         it('shows no events when filtering by non-existent label', () => {
             renderWithProviders({ viewOptionsValue: { activeEventLabelId: 'non-existent-label' } });
 
-            const listItems = screen.queryAllByRole('listitem');
-            expect(listItems).toHaveLength(0);
+            const eventCards = screen.queryAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(0);
         });
     });
 
@@ -132,8 +132,8 @@ describe('LoggableEventsList', () => {
         it('renders no list items when loggableEvents is empty', () => {
             renderWithProviders({ loggableEvents: [], viewOptionsValue: { activeEventLabelId: null } });
 
-            const listItems = screen.queryAllByRole('listitem');
-            expect(listItems).toHaveLength(0);
+            const eventCards = screen.queryAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(0);
         });
     });
 
@@ -141,8 +141,8 @@ describe('LoggableEventsList', () => {
         it('renders no list items when useFragment complete is false', () => {
             renderWithProviders({ skipCachePrepopulation: true });
 
-            const listItems = screen.queryAllByRole('listitem');
-            expect(listItems).toHaveLength(0);
+            const eventCards = screen.queryAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(0);
         });
 
         it('renders no list items when fragment is incomplete even with active filter', () => {
@@ -151,8 +151,8 @@ describe('LoggableEventsList', () => {
                 viewOptionsValue: { activeEventLabelId: 'label-work' }
             });
 
-            const listItems = screen.queryAllByRole('listitem');
-            expect(listItems).toHaveLength(0);
+            const eventCards = screen.queryAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(0);
         });
     });
 
@@ -171,8 +171,8 @@ describe('LoggableEventsList', () => {
                 loggableEvents: eventsWithoutLabels
             });
 
-            const listItems = screen.getAllByRole('listitem');
-            expect(listItems).toHaveLength(1);
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(1);
             expect(screen.getByTestId('loggable-event-card-event-no-labels')).toBeInTheDocument();
         });
 
@@ -190,8 +190,8 @@ describe('LoggableEventsList', () => {
                 loggableEvents: eventsWithoutLabels
             });
 
-            const listItems = screen.queryAllByRole('listitem');
-            expect(listItems).toHaveLength(0);
+            const eventCards = screen.queryAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(0);
         });
     });
 });


### PR DESCRIPTION
This pull request refactors the Event Card components to improve code reuse, layout consistency, and mobile responsiveness. A new `EventCardGridItem` component is introduced to standardize the grid layout for all event card variants. The changes also move UI state management to a shared hook (`useMuiState`) and enhance the mobile experience for event logging actions. Additionally, the shimmer loading effect is extracted into its own component and the corresponding tests are updated.

**Component Structure & Layout Standardization**
* Introduced the new `EventCardGridItem` component to provide a consistent grid wrapper for event cards, replacing direct usage of `Grid` and centralizing the card width (`DESKTOP_CARD_MAX_WIDTH`). All event card variants (`EventCard`, `CreateEventCard`, shimmer/loading, etc.) now use this wrapper for layout consistency. [[1]](diffhunk://#diff-ff5746d3e274950e7689e5ff4a2534b31d98ecaf1b1edfb09d1ffb622c2d6ba2R1-R22) [[2]](diffhunk://#diff-eb1f6d3c1e1ab4a7aabcf6c53e141bf4e1b2a6e54ea808afd7de1e28481945faL13-R13) [[3]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9L8-R12) [[4]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9L38-R29) [[5]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9L57-R46) [[6]](diffhunk://#diff-cd21227f96613934be50544a35f8457e458755fdede5ead4ad864ef3ea2f22d2R1-R25) [[7]](diffhunk://#diff-4c162e46b7b2b2e04e2ec6c662f2e1049130e7202c4ef5db15235ee60cdd4819L2) [[8]](diffhunk://#diff-4c162e46b7b2b2e04e2ec6c662f2e1049130e7202c4ef5db15235ee60cdd4819L59-R58)

**UI State Management**
* Refactored dark mode and mobile detection logic to use the shared `useMuiState` hook across multiple components (`EventCard`, `EditEventCard`, `LastEventDisplay`, `EventCardLogActions`), removing direct `useTheme` usage for better state management. [[1]](diffhunk://#diff-a581c73c4c2d884c7161ed09e5c93ab59357c15f963a0a8dd1afcd0b52a3dcfbL19) [[2]](diffhunk://#diff-a581c73c4c2d884c7161ed09e5c93ab59357c15f963a0a8dd1afcd0b52a3dcfbR27) [[3]](diffhunk://#diff-a581c73c4c2d884c7161ed09e5c93ab59357c15f963a0a8dd1afcd0b52a3dcfbL129-L135) [[4]](diffhunk://#diff-f951159bb7a112706d5bc31d9dac13e3ab8a590018e86018e49353715092fc11L6-R7) [[5]](diffhunk://#diff-f951159bb7a112706d5bc31d9dac13e3ab8a590018e86018e49353715092fc11L16-R18) [[6]](diffhunk://#diff-4818e15de9210b9d79b7c6eaf0bbe21fd1a0b4c68f655a47b9131941089ff70cR10) [[7]](diffhunk://#diff-4818e15de9210b9d79b7c6eaf0bbe21fd1a0b4c68f655a47b9131941089ff70cR24-R25)

**Mobile Responsiveness**
* Improved `EventCardLogActions` to adapt its layout for mobile devices, switching from a horizontal (`row`) to vertical (`column`) stack and making buttons full width on mobile. [[1]](diffhunk://#diff-4818e15de9210b9d79b7c6eaf0bbe21fd1a0b4c68f655a47b9131941089ff70cL45-R61) [[2]](diffhunk://#diff-4818e15de9210b9d79b7c6eaf0bbe21fd1a0b4c68f655a47b9131941089ff70cR80)

**Loading State Refactor**
* Extracted the shimmer loading effect into a new `EventCardShimmer` component, replacing the previous inline skeleton logic, and updated related tests to use the new component. [[1]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9L8-R12) [[2]](diffhunk://#diff-cd21227f96613934be50544a35f8457e458755fdede5ead4ad864ef3ea2f22d2R1-R25) [[3]](diffhunk://#diff-530f6d11c0c241969311f33754a6349aefe2f43e44467d6385999f187c6632acL4-R4) [[4]](diffhunk://#diff-530f6d11c0c241969311f33754a6349aefe2f43e44467d6385999f187c6632acL26-L44) [[5]](diffhunk://#diff-d5387a1db0505d2c5b1298f7b45f53bb7123eb4186bb283f7a41abfaed1ed3a5R1-R23)

**Testing Improvements**
* Updated and expanded tests for mobile responsiveness and shimmer loading, including parameterized tests for both desktop and mobile views and for light/dark modes. [[1]](diffhunk://#diff-2e6cddae5aaa6b6f2692d5cd044d8c42c557fbaf3157121000d637127feac8c0R6-R10) [[2]](diffhunk://#diff-2e6cddae5aaa6b6f2692d5cd044d8c42c557fbaf3157121000d637127feac8c0R36-R38) [[3]](diffhunk://#diff-2e6cddae5aaa6b6f2692d5cd044d8c42c557fbaf3157121000d637127feac8c0L47-R59) [[4]](diffhunk://#diff-d5387a1db0505d2c5b1298f7b45f53bb7123eb4186bb283f7a41abfaed1ed3a5R1-R23)

<img width="799" height="948" alt="image" src="https://github.com/user-attachments/assets/bf613c26-b4fb-48ed-bf4f-eae9afbac369" />

<img width="1483" height="973" alt="image" src="https://github.com/user-attachments/assets/68f88f82-e28d-44f9-92f6-1104030a28fb" />
