### PR TITLE
fix event card dropdown menu clipping too far to right

### DIFF
--- a/apps/web/src/components/EventCards/EventCardHeader.tsx
+++ b/apps/web/src/components/EventCards/EventCardHeader.tsx
@@ -32,9 +32,9 @@ const EventCardHeader = ({ eventId, name, onEditEvent, onDeleteEvent }: Props) =
     };
 
     return (
-        <Grid container alignItems="baseline" sx={{ mb: 1.5 }}>
+        <Grid container alignItems="center" sx={{ mb: 1.5 }}>
             <Grid size={11}>
-                <Typography gutterBottom variant="h5" id={`event-title-${eventId}`} component="h2">
+                <Typography variant="h5" id={`event-title-${eventId}`} component="h2">
                     {name}
                 </Typography>
             </Grid>

--- a/apps/web/src/components/EventCards/EventCardHeader.tsx
+++ b/apps/web/src/components/EventCards/EventCardHeader.tsx
@@ -32,7 +32,7 @@ const EventCardHeader = ({ eventId, name, onEditEvent, onDeleteEvent }: Props) =
     };
 
     return (
-        <Grid container alignItems="baseline">
+        <Grid container alignItems="baseline" sx={{ mb: 1.5 }}>
             <Grid size={11}>
                 <Typography gutterBottom variant="h5" id={`event-title-${eventId}`} component="h2">
                     {name}

--- a/apps/web/src/components/EventCards/EventOptionsDropdown.tsx
+++ b/apps/web/src/components/EventCards/EventOptionsDropdown.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 
 import { css } from '@emotion/react';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -13,6 +13,8 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import { blue } from '@mui/material/colors';
+
+const DROPDOWN_WIDTH = 200;
 
 const DropdownItem = ({ name, icon, onClick }: { name: string; icon: ReactNode; onClick: () => void }) => (
     <ListItem disablePadding>
@@ -39,17 +41,37 @@ type EventOptionsDropdownProps = {
 };
 
 const EventOptionsDropdown = ({ onDismiss, onEditEventClick, onDeleteEventClick }: EventOptionsDropdownProps) => {
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const [alignRight, setAlignRight] = useState(false);
+
+    useEffect(() => {
+        // istanbul ignore else
+        if (dropdownRef.current) {
+            const parentRect = dropdownRef.current.parentElement?.getBoundingClientRect();
+
+            // istanbul ignore else
+            if (parentRect) {
+                // Check if dropdown would overflow right edge of viewport
+                const wouldOverflowRight = parentRect.left + DROPDOWN_WIDTH > window.innerWidth;
+                setAlignRight(wouldOverflowRight);
+            }
+        }
+    }, []);
+
     return (
         <ClickAwayListener onClickAway={onDismiss}>
             <Paper
+                ref={dropdownRef}
                 elevation={5}
                 role="menu"
                 aria-label="Event options menu"
                 css={css`
                     position: absolute;
-                    width: 200px;
+                    width: ${DROPDOWN_WIDTH}px;
+                    top: 100%;
                     // https://mui.com/material-ui/customization/z-index/#main-content
                     z-index: 1500;
+                    ${alignRight ? 'right: 0;' : 'left: 0;'}
                 `}
             >
                 <List disablePadding role="none">


### PR DESCRIPTION
This pull request improves the positioning and responsiveness of the `EventOptionsDropdown` component, ensuring it aligns correctly within the viewport and does not overflow off-screen. It introduces logic to dynamically align the dropdown to the left or right edge of its parent based on available space, and adds thorough tests to verify this behavior.

**Viewport-aware dropdown positioning:**

* Added logic in `EventOptionsDropdown.tsx` to detect potential right-edge overflow and conditionally align the dropdown either left or right, using a new `alignRight` state and `useEffect` for calculation. (`[apps/web/src/components/EventCards/EventOptionsDropdown.tsxR44-R74](diffhunk://#diff-675d30354bb263110ddec2e6912bc86c8c88325add358ee39869312f815f71b9R44-R74)`)
* Defined a constant `DROPDOWN_WIDTH` to standardize dropdown sizing and used it in positioning calculations. (`[apps/web/src/components/EventCards/EventOptionsDropdown.tsxR17-R18](diffhunk://#diff-675d30354bb263110ddec2e6912bc86c8c88325add358ee39869312f815f71b9R17-R18)`)
* Updated dropdown rendering to use a ref for parent measurements and to set CSS positioning dynamically based on alignment. (`[apps/web/src/components/EventCards/EventOptionsDropdown.tsxR44-R74](diffhunk://#diff-675d30354bb263110ddec2e6912bc86c8c88325add358ee39869312f815f71b9R44-R74)`)

**Testing improvements:**

* Added a comprehensive test suite for viewport-aware positioning in `EventOptionsDropdown.test.js`, including scenarios for left/right alignment and dynamic visibility toggling. (`[apps/web/src/components/EventCards/__tests__/EventOptionsDropdown.test.jsR61-R157](diffhunk://#diff-03d358d2af6d30ec95114c3060dd44744be80a62f4d5d0cd01af911dea2df86dR61-R157)`)
* Included React hooks and test utilities in the test file to support new test cases. (`[apps/web/src/components/EventCards/__tests__/EventOptionsDropdown.test.jsR1-R2](diffhunk://#diff-03d358d2af6d30ec95114c3060dd44744be80a62f4d5d0cd01af911dea2df86dR1-R2)`)

**Minor UI enhancement:**

* Added bottom margin to the `EventCardHeader` for improved spacing. (`[apps/web/src/components/EventCards/EventCardHeader.tsxL35-R35](diffhunk://#diff-34cc3aec98ef68eff413d94c6a6d8cb333a43331a204a821cd9b6db9de357876L35-R35)`)

<img width="1482" height="705" alt="image" src="https://github.com/user-attachments/assets/5ac91cef-fccb-4b7c-9609-f6b9446b3e7e" />

<img width="1471" height="663" alt="image" src="https://github.com/user-attachments/assets/dc04d0f0-3bb1-477b-bb5f-447c0bf64ed3" />

