### PR TITLE
tweaks to event card header for mobile

### DIFF
--- a/apps/web/src/components/EventCards/EventCardHeader.tsx
+++ b/apps/web/src/components/EventCards/EventCardHeader.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 
 import EventOptionsDropdown from './EventOptionsDropdown';
 
+import useMuiState from '../../hooks/useMuiState';
 import { useToggle } from '../../utils/useToggle';
 
 type Props = {
@@ -20,6 +21,7 @@ type Props = {
 
 const EventCardHeader = ({ eventId, name, onEditEvent, onDeleteEvent }: Props) => {
     const { value: isDropdownShowing, setTrue: showDropdown, setFalse: hideDropdown } = useToggle();
+    const { isMobile } = useMuiState();
 
     const handleEditClick = () => {
         onEditEvent();
@@ -32,9 +34,9 @@ const EventCardHeader = ({ eventId, name, onEditEvent, onDeleteEvent }: Props) =
     };
 
     return (
-        <Grid container alignItems="center" sx={{ mb: 1.5 }}>
+        <Grid container alignItems="center" sx={{ mb: 1.5, pr: 1 }}>
             <Grid size={11}>
-                <Typography variant="h5" id={`event-title-${eventId}`} component="h2">
+                <Typography variant={isMobile ? 'h6' : 'h5'} id={`event-title-${eventId}`} component="h2">
                     {name}
                 </Typography>
             </Grid>
@@ -50,6 +52,7 @@ const EventCardHeader = ({ eventId, name, onEditEvent, onDeleteEvent }: Props) =
                         aria-expanded={isDropdownShowing}
                         aria-haspopup="menu"
                         component="span"
+                        size="small"
                     >
                         <MoreVertIcon />
                     </IconButton>

--- a/apps/web/src/components/EventCards/__tests__/EventCardHeader.test.js
+++ b/apps/web/src/components/EventCards/__tests__/EventCardHeader.test.js
@@ -1,0 +1,142 @@
+import { createTheme } from '@mui/material/styles';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import useMuiState from '../../../hooks/useMuiState';
+import EventCardHeader from '../EventCardHeader';
+
+jest.mock('../../../hooks/useMuiState');
+
+describe('EventCardHeader', () => {
+    let user;
+    const mockOnEditEvent = jest.fn();
+    const mockOnDeleteEvent = jest.fn();
+
+    const defaultProps = {
+        eventId: 'event-123',
+        name: 'Test Event',
+        onEditEvent: mockOnEditEvent,
+        onDeleteEvent: mockOnDeleteEvent
+    };
+
+    beforeEach(() => {
+        user = userEvent.setup();
+        jest.clearAllMocks();
+        useMuiState.mockReturnValue({
+            theme: createTheme(),
+            isMobile: false,
+            isDarkMode: false
+        });
+    });
+
+    it('renders in desktop view', () => {
+        useMuiState.mockReturnValue({
+            theme: createTheme(),
+            isMobile: false,
+            isDarkMode: false
+        });
+
+        render(<EventCardHeader {...defaultProps} />);
+
+        expect(screen.getByText('Test Event')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Event options for Test Event' })).toBeInTheDocument();
+    });
+
+    it('renders in mobile view', () => {
+        useMuiState.mockReturnValue({
+            theme: createTheme(),
+            isMobile: true,
+            isDarkMode: false
+        });
+
+        render(<EventCardHeader {...defaultProps} />);
+
+        expect(screen.getByText('Test Event')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Event options for Test Event' })).toBeInTheDocument();
+    });
+
+    it('shows dropdown when options button is clicked', async () => {
+        render(<EventCardHeader {...defaultProps} />);
+
+        const optionsButton = screen.getByRole('button', { name: 'Event options for Test Event' });
+        await user.click(optionsButton);
+
+        expect(screen.getByRole('menu', { name: 'Event options menu' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Edit event' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Delete event' })).toBeInTheDocument();
+    });
+
+    it('hides dropdown when clicking away', async () => {
+        render(<EventCardHeader {...defaultProps} />);
+
+        const optionsButton = screen.getByRole('button', { name: 'Event options for Test Event' });
+        await user.click(optionsButton);
+
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+
+        // Click outside the dropdown
+        user.click(document.body);
+
+        await waitForElementToBeRemoved(() => screen.queryByRole('menu'));
+    });
+
+    it('calls onEditEvent and hides dropdown when edit is clicked', async () => {
+        render(<EventCardHeader {...defaultProps} />);
+
+        const optionsButton = screen.getByRole('button', { name: 'Event options for Test Event' });
+        await user.click(optionsButton);
+
+        const editButton = screen.getByRole('menuitem', { name: 'Edit event' });
+        await user.click(editButton);
+
+        expect(mockOnEditEvent).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('calls onDeleteEvent and hides dropdown when delete is clicked', async () => {
+        render(<EventCardHeader {...defaultProps} />);
+
+        const optionsButton = screen.getByRole('button', { name: 'Event options for Test Event' });
+        await user.click(optionsButton);
+
+        const deleteButton = screen.getByRole('menuitem', { name: 'Delete event' });
+        await user.click(deleteButton);
+
+        expect(mockOnDeleteEvent).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it.each([
+        ['short name', 'A'],
+        ['long name', 'This is a very long event name that should still render properly'],
+        ['special characters', 'Event with @#$%^&*() special chars!']
+    ])('renders correctly with %s', (_, eventName) => {
+        render(<EventCardHeader {...defaultProps} name={eventName} />);
+
+        expect(screen.getByText(eventName)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: `Event options for ${eventName}` })).toBeInTheDocument();
+    });
+
+    it('handles multiple dropdown interactions', async () => {
+        render(<EventCardHeader {...defaultProps} />);
+
+        const optionsButton = screen.getByRole('button', { name: 'Event options for Test Event' });
+
+        // Open dropdown
+        await user.click(optionsButton);
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+
+        // Close by clicking outside
+        user.click(document.body);
+        await waitForElementToBeRemoved(() => screen.queryByRole('menu'));
+
+        // Open again
+        await user.click(optionsButton);
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+
+        // Close by clicking edit
+        await user.click(screen.getByRole('menuitem', { name: 'Edit event' }));
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        expect(mockOnEditEvent).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
This pull request enhances the `EventCardHeader` component to better support responsive design and accessibility, and adds a comprehensive test suite to ensure correct behavior across device types and user interactions.

**Component improvements:**

* The `EventCardHeader` now uses the `useMuiState` hook to determine if the view is mobile, allowing the header text size to adjust dynamically (`variant` is `'h6'` for mobile, `'h5'` otherwise) and adding right padding for improved layout. (`[[1]](diffhunk://#diff-34cc3aec98ef68eff413d94c6a6d8cb333a43331a204a821cd9b6db9de357876R12)`, `[[2]](diffhunk://#diff-34cc3aec98ef68eff413d94c6a6d8cb333a43331a204a821cd9b6db9de357876R24)`, `[[3]](diffhunk://#diff-34cc3aec98ef68eff413d94c6a6d8cb333a43331a204a821cd9b6db9de357876L35-R39)`)
* The event options button now explicitly sets its size to `"small"` for better alignment and appearance. (`[apps/web/src/components/EventCards/EventCardHeader.tsxR55](diffhunk://#diff-34cc3aec98ef68eff413d94c6a6d8cb333a43331a204a821cd9b6db9de357876R55)`)

**Testing improvements:**

* A new test file, `EventCardHeader.test.js`, was added with thorough tests covering desktop and mobile rendering, dropdown interactions, callback invocations, and edge cases with event names. The `useMuiState` hook is mocked to simulate different device contexts. (`[apps/web/src/components/EventCards/__tests__/EventCardHeader.test.jsR1-R142](diffhunk://#diff-21a3d2a1a654348aceb65bffc30f5622eb1cb888e90ec7c5d53e87dacbcdb64bR1-R142)`)

<img width="446" height="881" alt="image" src="https://github.com/user-attachments/assets/61427c6c-abc3-48a0-b81c-5fcc4dd6bfc7" />

<img width="1429" height="526" alt="image" src="https://github.com/user-attachments/assets/4f7849b5-add4-4575-aeaf-885c68ff4e56" />
