### PR TITLE
Refactor sidebar actions and add variant for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ happened and stay on top of your routines.
 
 Visually inspired by Google Keep and conceptually inspired by logging systems used to measure user interaction in apps.
 
+## Features
+
+- **Frontend**: React TypeScript app with Material UI, Apollo GraphQL, offline support via apollo3-cache-persist, and Jest for testing
+- **Backend**: GraphQL Yoga API with JWT authentication, Prisma ORM with MongoDB Atlas database, sqids for encoding IDs, and Vitest for testing
+- **Authentication**: Google OAuth login with JWT tokens, secure cookie storage, and refresh token implementation
+
+See individual app READMEs for detailed information:
+- [Frontend Documentation](./apps/web/README.md)
+- [Backend Documentation](./apps/api/README.md)
+
 ## Project History
 
 This project started in 2022 before Create React App (CRA) was sunset. Picked this project back up in 2025 to learn new
@@ -79,13 +89,3 @@ A MongoDB Atlas database is also required for the backend. Set the `DATABASE_URL
 `.env` file.
 
 See the individual apps' `.env.example` files for more details on required environment variables.
-
-## Features
-
-- **Frontend**: React TypeScript app with Material UI, Apollo GraphQL, offline support via apollo3-cache-persist, and Jest for testing
-- **Backend**: GraphQL Yoga API with JWT authentication, Prisma ORM, MongoDB Atlas database, sqids for encoding IDs, and Vitest for testing
-- **Authentication**: Google OAuth login with JWT tokens, secure cookie storage, and refresh token implementation
-
-See individual app READMEs for detailed information:
-- [Frontend Documentation](./apps/web/README.md)
-- [Backend Documentation](./apps/api/README.md)

--- a/apps/web/src/components/EventLabels/CreateEventLabelForm.tsx
+++ b/apps/web/src/components/EventLabels/CreateEventLabelForm.tsx
@@ -43,10 +43,10 @@ const CreateEventLabelForm = ({ onCancel, onSuccess, existingLabelNames }: Props
                 onClick={handleCancelCreate}
                 size="small"
                 color="default"
-                sx={{ ml: 1.25, mr: 1, mt: 0.5 }}
+                sx={{ ml: 1.25, mr: 0.5, mt: 0.25 }}
                 aria-label="Cancel label creation"
             >
-                <CancelIcon />
+                <CancelIcon fontSize="small" />
             </IconButton>
             <Box sx={{ flex: 1, mr: 1 }}>
                 <TextField
@@ -68,7 +68,7 @@ const CreateEventLabelForm = ({ onCancel, onSuccess, existingLabelNames }: Props
                     InputProps={{
                         sx: {
                             padding: '0px 8px',
-                            height: 36
+                            height: 28
                         }
                     }}
                 />
@@ -78,10 +78,10 @@ const CreateEventLabelForm = ({ onCancel, onSuccess, existingLabelNames }: Props
                 size="small"
                 color="primary"
                 disabled={isTooLong || isDuplicate || isEmpty || createIsLoading}
-                sx={{ mt: 0.5 }}
+                sx={{ mt: 0.25 }}
                 aria-label="Create label"
             >
-                <CheckIcon />
+                <CheckIcon fontSize="small" />
             </IconButton>
         </Box>
     );

--- a/apps/web/src/components/EventLabels/EventLabel.tsx
+++ b/apps/web/src/components/EventLabels/EventLabel.tsx
@@ -112,22 +112,22 @@ const EventLabel = ({ eventLabelId, isShowingEditActions, existingLabelNames }: 
                             disabled={validationError !== null || updateIsLoading}
                             aria-label="save"
                         >
-                            <CheckIcon />
+                            <CheckIcon fontSize="small" />
                         </IconButton>
                     ) : (
                         <IconButton edge="end" size="small" onClick={handleEditClick} aria-label="edit">
-                            <EditIcon />
+                            <EditIcon fontSize="small" />
                         </IconButton>
                     )
                 ) : null
             }
         >
-            <ListItemButton dense disableRipple onClick={handleLabelClick} selected={isActive}>
-                <ListItemIcon>
+            <ListItemButton dense disableRipple onClick={handleLabelClick} selected={isActive} sx={{ py: 0.5 }}>
+                <ListItemIcon sx={{ minWidth: 36 }}>
                     {isShowingEditActions ? (
                         isEditingName ? (
                             <IconButton edge="start" size="small" onClick={handleCancelEdit} aria-label="cancel">
-                                <CancelIcon />
+                                <CancelIcon fontSize="small" />
                             </IconButton>
                         ) : (
                             <IconButton
@@ -137,11 +137,11 @@ const EventLabel = ({ eventLabelId, isShowingEditActions, existingLabelNames }: 
                                 disabled={deleteIsLoading}
                                 aria-label="delete"
                             >
-                                <DeleteIcon />
+                                <DeleteIcon fontSize="small" />
                             </IconButton>
                         )
                     ) : (
-                        <LabelIcon />
+                        <LabelIcon fontSize="small" />
                     )}
                 </ListItemIcon>
                 {isShowingEditActions && isEditingName ? (

--- a/apps/web/src/components/EventLabels/EventLabelList.tsx
+++ b/apps/web/src/components/EventLabels/EventLabelList.tsx
@@ -64,7 +64,7 @@ const EventLabelList = ({ isShowingEditActions }: Props) => {
 
     return (
         <Box>
-            <List disablePadding>
+            <List disablePadding dense>
                 <ListItem disablePadding>
                     {createLabelFormIsShowing ? (
                         <CreateEventLabelForm
@@ -73,9 +73,9 @@ const EventLabelList = ({ isShowingEditActions }: Props) => {
                             existingLabelNames={existingLabelNames}
                         />
                     ) : (
-                        <ListItemButton dense disableRipple onClick={showCreateLabelForm}>
-                            <ListItemIcon>
-                                <AddIcon />
+                        <ListItemButton dense disableRipple onClick={showCreateLabelForm} sx={{ py: 0.5 }}>
+                            <ListItemIcon sx={{ minWidth: 35 }}>
+                                <AddIcon fontSize="small" />
                             </ListItemIcon>
                             <ListItemText primary="Create new label" />
                         </ListItemButton>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,25 +1,19 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import Brightness7Icon from '@mui/icons-material/Brightness7';
-import EditIcon from '@mui/icons-material/Edit';
-import EditIconOutlined from '@mui/icons-material/EditOutlined';
-import GitHubIcon from '@mui/icons-material/GitHub';
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
-import LogoutIcon from '@mui/icons-material/Logout';
 import Box from '@mui/material/Box';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
-import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { blueGrey, green } from '@mui/material/colors';
 
 import EventLabelList from './EventLabels/EventLabelList';
 import EventLabelShimmer from './EventLabels/EventLabelShimmer';
+import SidebarActions from './SidebarActions';
 
 import { useAuthMutations } from '../hooks/useAuthMutations';
 import useMuiState from '../hooks/useMuiState';
@@ -137,67 +131,35 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
                                         <EventLabelShimmer />
                                     </>
                                 ) : (
-                                    <EventLabelList isShowingEditActions={isEditingLabels} />
+                                    <>
+                                        <EventLabelList isShowingEditActions={isEditingLabels} />
+                                        {isMobile && (
+                                            <SidebarActions
+                                                variant="list"
+                                                isEditingLabels={isEditingLabels}
+                                                onToggleTheme={handleToggleTheme}
+                                                onToggleEditLabels={() =>
+                                                    isEditingLabels ? stopEditingLabels() : startEditingLabels()
+                                                }
+                                                onLogout={handleLogout}
+                                            />
+                                        )}
+                                    </>
                                 )}
                             </Box>
                         </Box>
                     </Collapse>
 
-                    <Box
-                        sx={{
-                            position: 'absolute',
-                            left: isCollapsed ? -999 : 8,
-                            bottom: 16,
-                            display: 'flex',
-                            justifyContent: 'flex-start',
-                            zIndex: 1
-                        }}
-                    >
-                        <Tooltip title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}>
-                            <IconButton
-                                onClick={handleToggleTheme}
-                                aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-                            >
-                                {isDarkMode ? <Brightness7Icon /> : <Brightness4Icon />}
-                            </IconButton>
-                        </Tooltip>
-                        <Tooltip title={isEditingLabels ? 'Stop editing labels' : 'Manage labels'}>
-                            <ToggleButton
-                                value="edit"
-                                selected={isEditingLabels}
-                                onChange={() => (isEditingLabels ? stopEditingLabels() : startEditingLabels())}
-                                sx={{
-                                    ml: 1,
-                                    border: 'none',
-                                    borderRadius: '50%',
-                                    '&:hover': {
-                                        border: 'none'
-                                    }
-                                }}
-                                size="small"
-                                aria-label={isEditingLabels ? 'Stop editing labels' : 'Manage labels'}
-                            >
-                                {isEditingLabels ? <EditIcon color="action" /> : <EditIconOutlined />}
-                            </ToggleButton>
-                        </Tooltip>
-                        <Tooltip title="View on GitHub">
-                            <IconButton
-                                component="a"
-                                href="https://github.com/nathanchica/life_event_logger"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                sx={{ ml: 1 }}
-                                aria-label="View on GitHub"
-                            >
-                                <GitHubIcon />
-                            </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Logout">
-                            <IconButton onClick={handleLogout} sx={{ ml: 1 }} aria-label="Logout">
-                                <LogoutIcon />
-                            </IconButton>
-                        </Tooltip>
-                    </Box>
+                    {!isMobile && (
+                        <SidebarActions
+                            variant="toolbar"
+                            isCollapsed={isCollapsed}
+                            isEditingLabels={isEditingLabels}
+                            onToggleTheme={handleToggleTheme}
+                            onToggleEditLabels={() => (isEditingLabels ? stopEditingLabels() : startEditingLabels())}
+                            onLogout={handleLogout}
+                        />
+                    )}
                 </Paper>
             </Collapse>
         </ClickAwayListener>

--- a/apps/web/src/components/SidebarActions.tsx
+++ b/apps/web/src/components/SidebarActions.tsx
@@ -1,0 +1,154 @@
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+import EditIcon from '@mui/icons-material/Edit';
+import EditIconOutlined from '@mui/icons-material/EditOutlined';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LogoutIcon from '@mui/icons-material/Logout';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import ToggleButton from '@mui/material/ToggleButton';
+import Tooltip from '@mui/material/Tooltip';
+
+import useMuiState from '../hooks/useMuiState';
+
+type Props = {
+    variant: 'list' | 'toolbar';
+    isEditingLabels: boolean;
+    onToggleTheme: () => void;
+    onToggleEditLabels: () => void;
+    onLogout: () => void;
+    isCollapsed?: boolean;
+};
+
+const SidebarActions = ({
+    variant,
+    isEditingLabels,
+    onToggleTheme,
+    onToggleEditLabels,
+    onLogout,
+    isCollapsed = false
+}: Props) => {
+    const { isDarkMode } = useMuiState();
+
+    const actions = [
+        {
+            key: 'theme',
+            icon: isDarkMode ? <Brightness7Icon fontSize="small" /> : <Brightness4Icon fontSize="small" />,
+            label: isDarkMode ? 'Switch to light mode' : 'Switch to dark mode',
+            onClick: onToggleTheme,
+            isToggle: false,
+            selected: false
+        },
+        {
+            key: 'edit',
+            icon: isEditingLabels ? (
+                <EditIcon color="action" fontSize="small" />
+            ) : (
+                <EditIconOutlined fontSize="small" />
+            ),
+            label: isEditingLabels ? 'Stop editing labels' : 'Manage labels',
+            onClick: onToggleEditLabels,
+            isToggle: true,
+            selected: isEditingLabels
+        },
+        {
+            key: 'github',
+            icon: <GitHubIcon fontSize="small" />,
+            label: 'View on GitHub',
+            onClick: () => window.open('https://github.com/nathanchica/life_event_logger_monorepo', '_blank'),
+            isToggle: false,
+            selected: false,
+            isLink: true,
+            href: 'https://github.com/nathanchica/life_event_logger_monorepo'
+        },
+        {
+            key: 'logout',
+            icon: <LogoutIcon fontSize="small" />,
+            label: 'Logout',
+            onClick: onLogout,
+            isToggle: false,
+            selected: false
+        }
+    ];
+
+    if (variant === 'list') {
+        return (
+            <List dense disablePadding>
+                {actions.map((action) => (
+                    <ListItem key={action.key} disablePadding>
+                        <ListItemButton
+                            onClick={action.onClick}
+                            selected={action.selected}
+                            sx={{ py: 0.5 }}
+                            component={action.isLink ? 'a' : 'div'}
+                            href={action.href}
+                            target={action.isLink ? '_blank' : undefined}
+                            rel={action.isLink ? 'noopener noreferrer' : undefined}
+                        >
+                            <ListItemIcon sx={{ minWidth: 36 }}>{action.icon}</ListItemIcon>
+                            <ListItemText primary={action.label} />
+                        </ListItemButton>
+                    </ListItem>
+                ))}
+            </List>
+        );
+    }
+
+    // toolbar variant
+    return (
+        <Box
+            sx={{
+                position: 'absolute',
+                left: isCollapsed ? -999 : 8,
+                bottom: 16,
+                display: 'flex',
+                justifyContent: 'flex-start',
+                zIndex: 1
+            }}
+        >
+            {actions.map((action, index) => (
+                <Tooltip key={action.key} title={action.label}>
+                    {action.isToggle ? (
+                        <ToggleButton
+                            value="edit"
+                            selected={action.selected}
+                            onChange={action.onClick}
+                            sx={{
+                                // ignoring coverage here since it's not possible to test with current actions
+                                ml: /* istanbul ignore next */ index > 0 ? 1 : 0,
+                                border: 'none',
+                                borderRadius: '50%',
+                                '&:hover': {
+                                    border: 'none'
+                                }
+                            }}
+                            size="small"
+                            aria-label={action.label}
+                        >
+                            {action.icon}
+                        </ToggleButton>
+                    ) : (
+                        <IconButton
+                            onClick={action.onClick}
+                            component={action.isLink ? 'a' : 'button'}
+                            href={action.href}
+                            target={action.isLink ? '_blank' : undefined}
+                            rel={action.isLink ? 'noopener noreferrer' : undefined}
+                            sx={{ ml: index > 0 ? 1 : 0 }}
+                            aria-label={action.label}
+                        >
+                            {action.icon}
+                        </IconButton>
+                    )}
+                </Tooltip>
+            ))}
+        </Box>
+    );
+};
+
+export default SidebarActions;

--- a/apps/web/src/components/SidebarActions.tsx
+++ b/apps/web/src/components/SidebarActions.tsx
@@ -60,7 +60,6 @@ const SidebarActions = ({
             key: 'github',
             icon: <GitHubIcon fontSize="small" />,
             label: 'View on GitHub',
-            onClick: () => window.open('https://github.com/nathanchica/life_event_logger_monorepo', '_blank'),
             isToggle: false,
             selected: false,
             isLink: true,

--- a/apps/web/src/components/__tests__/Sidebar.test.js
+++ b/apps/web/src/components/__tests__/Sidebar.test.js
@@ -228,7 +228,11 @@ describe('Sidebar', () => {
     });
 
     describe('Edit Labels Toggle', () => {
-        it('toggles between edit and non-edit mode', async () => {
+        it('toggles between edit and non-edit mode in desktop view', async () => {
+            useMuiState.mockReturnValue({
+                isMobile: false,
+                isDarkMode: false
+            });
             renderWithProviders(<Sidebar {...defaultProps} />, { eventLabels: mockEventLabels });
 
             // Initially should show "Manage labels"
@@ -248,6 +252,32 @@ describe('Sidebar', () => {
             // Should be back to "Manage labels"
             expect(screen.getByLabelText('Manage labels')).toBeInTheDocument();
             expect(screen.queryByLabelText('Stop editing labels')).not.toBeInTheDocument();
+        });
+
+        it('toggles between edit and non-edit mode in mobile view', async () => {
+            useMuiState.mockReturnValue({
+                isMobile: true,
+                isDarkMode: false
+            });
+            renderWithProviders(<Sidebar {...defaultProps} />, { eventLabels: mockEventLabels });
+
+            // Initially should show "Manage labels" as text in list item
+            const manageButton = screen.getByText('Manage labels');
+            expect(manageButton).toBeInTheDocument();
+
+            // Click to enter edit mode
+            await user.click(manageButton);
+
+            // Should now show "Stop editing labels" as text
+            expect(screen.getByText('Stop editing labels')).toBeInTheDocument();
+            expect(screen.queryByText('Manage labels')).not.toBeInTheDocument();
+
+            // Click again to exit edit mode
+            await user.click(screen.getByText('Stop editing labels'));
+
+            // Should be back to "Manage labels"
+            expect(screen.getByText('Manage labels')).toBeInTheDocument();
+            expect(screen.queryByText('Stop editing labels')).not.toBeInTheDocument();
         });
 
         it('exits editing mode when clicking away', async () => {

--- a/apps/web/src/components/__tests__/SidebarActions.test.js
+++ b/apps/web/src/components/__tests__/SidebarActions.test.js
@@ -1,0 +1,194 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import useMuiState from '../../hooks/useMuiState';
+import SidebarActions from '../SidebarActions';
+
+jest.mock('../../hooks/useMuiState');
+
+describe('SidebarActions', () => {
+    let user;
+    const mockOnToggleTheme = jest.fn();
+    const mockOnToggleEditLabels = jest.fn();
+    const mockOnLogout = jest.fn();
+    const mockWindowOpen = jest.fn();
+    const originalWindowOpen = window.open;
+
+    beforeEach(() => {
+        user = userEvent.setup();
+        jest.clearAllMocks();
+        useMuiState.mockReturnValue({ isDarkMode: false });
+        window.open = mockWindowOpen;
+    });
+
+    afterEach(() => {
+        window.open = originalWindowOpen;
+    });
+
+    describe('list variant', () => {
+        const renderComponent = (props = {}) => {
+            return render(
+                <SidebarActions
+                    variant="list"
+                    isEditingLabels={false}
+                    onToggleTheme={mockOnToggleTheme}
+                    onToggleEditLabels={mockOnToggleEditLabels}
+                    onLogout={mockOnLogout}
+                    {...props}
+                />
+            );
+        };
+
+        it('renders all action items as list items', () => {
+            renderComponent();
+
+            expect(screen.getByText('Switch to dark mode')).toBeInTheDocument();
+            expect(screen.getByText('Manage labels')).toBeInTheDocument();
+            expect(screen.getByText('View on GitHub')).toBeInTheDocument();
+            expect(screen.getByText('Logout')).toBeInTheDocument();
+        });
+
+        it.each([
+            ['theme toggle', 'Switch to dark mode', 'mockOnToggleTheme'],
+            ['edit labels', 'Manage labels', 'mockOnToggleEditLabels'],
+            ['logout', 'Logout', 'mockOnLogout']
+        ])('handles %s click', async (_, buttonText, handlerName) => {
+            renderComponent();
+            const handlers = {
+                mockOnToggleTheme,
+                mockOnToggleEditLabels,
+                mockOnLogout
+            };
+
+            await user.click(screen.getByText(buttonText));
+            expect(handlers[handlerName]).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles GitHub link click', async () => {
+            renderComponent();
+
+            await user.click(screen.getByText('View on GitHub'));
+            expect(mockWindowOpen).toHaveBeenCalledWith(
+                'https://github.com/nathanchica/life_event_logger_monorepo',
+                '_blank'
+            );
+        });
+
+        it('shows correct theme text when dark mode is enabled', () => {
+            useMuiState.mockReturnValue({ isDarkMode: true });
+            renderComponent();
+
+            expect(screen.getByText('Switch to light mode')).toBeInTheDocument();
+            expect(screen.queryByText('Switch to dark mode')).not.toBeInTheDocument();
+        });
+
+        it('shows correct edit labels text when editing', () => {
+            renderComponent({ isEditingLabels: true });
+
+            expect(screen.getByText('Stop editing labels')).toBeInTheDocument();
+            expect(screen.queryByText('Manage labels')).not.toBeInTheDocument();
+        });
+
+        it('marks edit button as selected when editing labels', () => {
+            renderComponent({ isEditingLabels: true });
+
+            const editButton = screen.getByRole('button', { name: /stop editing labels/i });
+            expect(editButton).toHaveClass('Mui-selected');
+        });
+    });
+
+    describe('toolbar variant', () => {
+        const renderComponent = (props = {}) => {
+            return render(
+                <SidebarActions
+                    variant="toolbar"
+                    isEditingLabels={false}
+                    onToggleTheme={mockOnToggleTheme}
+                    onToggleEditLabels={mockOnToggleEditLabels}
+                    onLogout={mockOnLogout}
+                    isCollapsed={false}
+                    {...props}
+                />
+            );
+        };
+
+        it('renders all action items as icon buttons', () => {
+            renderComponent();
+
+            expect(screen.getByLabelText('Switch to dark mode')).toBeInTheDocument();
+            expect(screen.getByLabelText('Manage labels')).toBeInTheDocument();
+            expect(screen.getByLabelText('View on GitHub')).toBeInTheDocument();
+            expect(screen.getByLabelText('Logout')).toBeInTheDocument();
+        });
+
+        it.each([
+            ['theme toggle', 'Switch to dark mode', 'mockOnToggleTheme'],
+            ['edit labels', 'Manage labels', 'mockOnToggleEditLabels'],
+            ['logout', 'Logout', 'mockOnLogout']
+        ])('handles %s click', async (_, ariaLabel, handlerName) => {
+            renderComponent();
+            const handlers = {
+                mockOnToggleTheme,
+                mockOnToggleEditLabels,
+                mockOnLogout
+            };
+
+            await user.click(screen.getByLabelText(ariaLabel));
+            expect(handlers[handlerName]).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles GitHub link click', async () => {
+            renderComponent();
+
+            await user.click(screen.getByLabelText('View on GitHub'));
+            expect(mockWindowOpen).toHaveBeenCalledWith(
+                'https://github.com/nathanchica/life_event_logger_monorepo',
+                '_blank'
+            );
+        });
+
+        it('shows correct theme aria-label when dark mode is enabled', () => {
+            useMuiState.mockReturnValue({ isDarkMode: true });
+            renderComponent();
+
+            expect(screen.getByLabelText('Switch to light mode')).toBeInTheDocument();
+            expect(screen.queryByLabelText('Switch to dark mode')).not.toBeInTheDocument();
+        });
+
+        it('shows correct edit labels aria-label when editing', () => {
+            renderComponent({ isEditingLabels: true });
+
+            expect(screen.getByLabelText('Stop editing labels')).toBeInTheDocument();
+            expect(screen.queryByLabelText('Manage labels')).not.toBeInTheDocument();
+        });
+
+        it('hides toolbar when sidebar is collapsed', () => {
+            const { container } = renderComponent({ isCollapsed: true });
+
+            const toolbar = container.querySelector('.MuiBox-root');
+            expect(toolbar).toHaveStyle({ left: '-999px' });
+        });
+
+        it('shows toolbar when sidebar is not collapsed', () => {
+            const { container } = renderComponent({ isCollapsed: false });
+
+            const toolbar = container.querySelector('.MuiBox-root');
+            expect(toolbar).toHaveStyle({ left: '8px' });
+        });
+
+        it('renders edit button as ToggleButton', () => {
+            renderComponent({ isEditingLabels: true });
+
+            const editButton = screen.getByLabelText('Stop editing labels');
+            expect(editButton.classList.toString()).toMatch(/MuiToggleButton/);
+            expect(editButton).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        it('renders edit button as unselected when not editing', () => {
+            renderComponent({ isEditingLabels: false });
+
+            const editButton = screen.getByLabelText('Manage labels');
+            expect(editButton).toHaveAttribute('aria-pressed', 'false');
+        });
+    });
+});

--- a/apps/web/src/components/__tests__/SidebarActions.test.js
+++ b/apps/web/src/components/__tests__/SidebarActions.test.js
@@ -11,18 +11,11 @@ describe('SidebarActions', () => {
     const mockOnToggleTheme = jest.fn();
     const mockOnToggleEditLabels = jest.fn();
     const mockOnLogout = jest.fn();
-    const mockWindowOpen = jest.fn();
-    const originalWindowOpen = window.open;
 
     beforeEach(() => {
         user = userEvent.setup();
         jest.clearAllMocks();
         useMuiState.mockReturnValue({ isDarkMode: false });
-        window.open = mockWindowOpen;
-    });
-
-    afterEach(() => {
-        window.open = originalWindowOpen;
     });
 
     describe('list variant', () => {
@@ -64,14 +57,13 @@ describe('SidebarActions', () => {
             expect(handlers[handlerName]).toHaveBeenCalledTimes(1);
         });
 
-        it('handles GitHub link click', async () => {
+        it('renders GitHub link with correct href', () => {
             renderComponent();
 
-            await user.click(screen.getByText('View on GitHub'));
-            expect(mockWindowOpen).toHaveBeenCalledWith(
-                'https://github.com/nathanchica/life_event_logger_monorepo',
-                '_blank'
-            );
+            const githubLink = screen.getByText('View on GitHub').closest('a');
+            expect(githubLink).toHaveAttribute('href', 'https://github.com/nathanchica/life_event_logger_monorepo');
+            expect(githubLink).toHaveAttribute('target', '_blank');
+            expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
         });
 
         it('shows correct theme text when dark mode is enabled', () => {
@@ -137,14 +129,13 @@ describe('SidebarActions', () => {
             expect(handlers[handlerName]).toHaveBeenCalledTimes(1);
         });
 
-        it('handles GitHub link click', async () => {
+        it('renders GitHub link with correct href', () => {
             renderComponent();
 
-            await user.click(screen.getByLabelText('View on GitHub'));
-            expect(mockWindowOpen).toHaveBeenCalledWith(
-                'https://github.com/nathanchica/life_event_logger_monorepo',
-                '_blank'
-            );
+            const githubLink = screen.getByLabelText('View on GitHub');
+            expect(githubLink).toHaveAttribute('href', 'https://github.com/nathanchica/life_event_logger_monorepo');
+            expect(githubLink).toHaveAttribute('target', '_blank');
+            expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
         });
 
         it('shows correct theme aria-label when dark mode is enabled', () => {


### PR DESCRIPTION
This pull request refactors the sidebar actions in the frontend to improve code organization, maintainability, and user experience across desktop and mobile views. It introduces a new `SidebarActions` component to centralize sidebar actions, updates icon usage for better visual consistency, and makes several UI refinements to the event label management components.

**Sidebar Refactor and Actions Consolidation:**

* Extracted sidebar action buttons (theme toggle, edit labels, GitHub link, logout) into a new reusable `SidebarActions` component, supporting both toolbar (desktop) and list (mobile) variants. This simplifies `Sidebar.tsx` and improves maintainability. [[1]](diffhunk://#diff-15ca789c22e18dc465d87227ad30feabfe57dc2828c8f34cb4006cdcd3b04217R1-R153) [[2]](diffhunk://#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1L4-R16) [[3]](diffhunk://#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1R134-R162)

**UI Consistency and Accessibility:**

* Standardized icon sizes by adding `fontSize="small"` to all sidebar and label-related icons for a more compact and consistent appearance. [[1]](diffhunk://#diff-1e8094ad3f9ec9e6d4448e4700da5d5653b5aa802640d201dba9170a9fba8919L46-R49) [[2]](diffhunk://#diff-1e8094ad3f9ec9e6d4448e4700da5d5653b5aa802640d201dba9170a9fba8919L81-R84) [[3]](diffhunk://#diff-16cb3ed99cc6085c61352ac4784cd12be6adfa7af0c5904ddff246a1f3361c01L115-R130) [[4]](diffhunk://#diff-16cb3ed99cc6085c61352ac4784cd12be6adfa7af0c5904ddff246a1f3361c01L140-R144) [[5]](diffhunk://#diff-abc21ca59a563b5da41748f082f4bbb0635f77b1c0260434335e1f44530ecd40L76-R78)

* Refined padding, margin, and sizing for label creation and editing components to improve alignment and touch targets, especially in mobile views. [[1]](diffhunk://#diff-1e8094ad3f9ec9e6d4448e4700da5d5653b5aa802640d201dba9170a9fba8919L46-R49) [[2]](diffhunk://#diff-1e8094ad3f9ec9e6d4448e4700da5d5653b5aa802640d201dba9170a9fba8919L71-R71) [[3]](diffhunk://#diff-1e8094ad3f9ec9e6d4448e4700da5d5653b5aa802640d201dba9170a9fba8919L81-R84) [[4]](diffhunk://#diff-abc21ca59a563b5da41748f082f4bbb0635f77b1c0260434335e1f44530ecd40L67-R67) [[5]](diffhunk://#diff-abc21ca59a563b5da41748f082f4bbb0635f77b1c0260434335e1f44530ecd40L76-R78)

**Testing and Documentation:**

* Updated sidebar tests to verify correct behavior of the edit labels toggle in both desktop and mobile views, ensuring the new `SidebarActions` logic works as intended. [[1]](diffhunk://#diff-b5bdcc54fc5be327abe2952a3df2fc39eb06f95e167cd4496855bd0f8639f5ddL231-R235) [[2]](diffhunk://#diff-b5bdcc54fc5be327abe2952a3df2fc39eb06f95e167cd4496855bd0f8639f5ddR257-R282)

* Moved the project features section in `README.md` for better clarity and navigation, without changing feature content. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-L91)

<img width="513" height="693" alt="image" src="https://github.com/user-attachments/assets/14ea4909-fbfd-42a7-9666-16b2508b9e51" />

<img width="662" height="934" alt="image" src="https://github.com/user-attachments/assets/c8a1df75-152b-46b1-8a89-d3464c01ece6" />

<img width="758" height="565" alt="image" src="https://github.com/user-attachments/assets/2922afb4-17ef-42df-8d40-7eb5b07a64b2" />
