### PR TITLE
remove hard set width for event shimmers

### DIFF
--- a/apps/web/src/components/EventCards/EventCardGridItem.tsx
+++ b/apps/web/src/components/EventCards/EventCardGridItem.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import Grid from '@mui/material/Grid';
 
-export const DESKTOP_CARD_MAX_WIDTH = '400px';
+const DESKTOP_CARD_MAX_WIDTH = '400px';
 
 type Props = {
     children: ReactNode;

--- a/apps/web/src/components/EventCards/EventCardShimmer.tsx
+++ b/apps/web/src/components/EventCards/EventCardShimmer.tsx
@@ -1,7 +1,7 @@
 import Grow from '@mui/material/Grow';
 import Skeleton from '@mui/material/Skeleton';
 
-import EventCardGridItem, { DESKTOP_CARD_MAX_WIDTH } from './EventCardGridItem';
+import EventCardGridItem from './EventCardGridItem';
 
 /**
  * EventCardShimmer component for displaying a shimmer effect while the event card data is loading.
@@ -13,7 +13,6 @@ const EventCardShimmer = () => {
                 <Skeleton
                     data-testid="event-card-shimmer"
                     variant="rectangular"
-                    width={DESKTOP_CARD_MAX_WIDTH}
                     height={200}
                     aria-label="Loading event card"
                 />


### PR DESCRIPTION
This pull request makes a minor refactor to how the `DESKTOP_CARD_MAX_WIDTH` constant is managed in the Event Card components. The constant is now local to `EventCardGridItem.tsx` and no longer exported or used in `EventCardShimmer.tsx`.

Most important changes:

**Codebase simplification:**

* [`apps/web/src/components/EventCards/EventCardGridItem.tsx`](diffhunk://#diff-ff5746d3e274950e7689e5ff4a2534b31d98ecaf1b1edfb09d1ffb622c2d6ba2L5-R5): Changed `DESKTOP_CARD_MAX_WIDTH` from an exported to a local constant, making it internal to the file.
* [`apps/web/src/components/EventCards/EventCardShimmer.tsx`](diffhunk://#diff-cd21227f96613934be50544a35f8457e458755fdede5ead4ad864ef3ea2f22d2L4-R4): Updated import to remove `DESKTOP_CARD_MAX_WIDTH` and stopped using it in the `Skeleton` component, simplifying the code and reducing unnecessary coupling between components. [[1]](diffhunk://#diff-cd21227f96613934be50544a35f8457e458755fdede5ead4ad864ef3ea2f22d2L4-R4) [[2]](diffhunk://#diff-cd21227f96613934be50544a35f8457e458755fdede5ead4ad864ef3ea2f22d2L16)