### PR TITLE
add search by label name functionality

### DIFF
--- a/apps/web/src/components/LoggableEvents/LoggableEventsList.tsx
+++ b/apps/web/src/components/LoggableEvents/LoggableEventsList.tsx
@@ -13,6 +13,7 @@ type LoggableEventFragment = {
     name: string;
     labels: Array<{
         id: string;
+        name: string;
     }>;
 };
 
@@ -23,6 +24,7 @@ const LOGGABLE_EVENTS_FOR_USER_FRAGMENT = gql`
             name
             labels {
                 id
+                name
             }
         }
     }
@@ -61,7 +63,7 @@ const LoggableEventsList = ({ searchTerm = '' }: Props) => {
     const fuse = useMemo(
         () =>
             new Fuse(labelFilteredEvents, {
-                keys: ['name'],
+                keys: ['name', 'labels.name'],
                 threshold: 0.3,
                 includeScore: false
             }),

--- a/apps/web/src/components/LoggableEvents/__tests__/LoggableEventsList.test.js
+++ b/apps/web/src/components/LoggableEvents/__tests__/LoggableEventsList.test.js
@@ -270,6 +270,56 @@ describe('LoggableEventsList', () => {
             expect(eventCards).toHaveLength(1);
             expect(screen.getByTestId('loggable-event-card-event-1')).toBeInTheDocument();
         });
+
+        it('filters events by label name', () => {
+            renderWithProviders({ searchTerm: 'Health', viewOptionsValue: { activeEventLabelId: null } });
+
+            // Should find Gym Session which has the Health label
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(1);
+            expect(screen.getByTestId('loggable-event-card-event-2')).toBeInTheDocument();
+        });
+
+        it('filters events by partial label name match', () => {
+            renderWithProviders({ searchTerm: 'Soc', viewOptionsValue: { activeEventLabelId: null } });
+
+            // Should find Team Building which has the Social label
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(1);
+            expect(screen.getByTestId('loggable-event-card-event-3')).toBeInTheDocument();
+        });
+
+        it('finds all events with matching label name', () => {
+            renderWithProviders({ searchTerm: 'Work', viewOptionsValue: { activeEventLabelId: null } });
+
+            // Should find Work Meeting and Team Building (both have Work label)
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(2);
+            expect(screen.getByTestId('loggable-event-card-event-1')).toBeInTheDocument();
+            expect(screen.getByTestId('loggable-event-card-event-3')).toBeInTheDocument();
+        });
+
+        it('matches either event name or label name', () => {
+            // Add an event with a name that doesn't match its label
+            const customEvents = [
+                createMockLoggableEventFragment({
+                    id: 'event-4',
+                    name: 'Going for a walk',
+                    labels: [createMockEventLabelFragment({ id: 'label-health', name: 'Health' })]
+                })
+            ];
+
+            renderWithProviders({
+                searchTerm: 'Health',
+                viewOptionsValue: { activeEventLabelId: null },
+                loggableEvents: customEvents
+            });
+
+            // Should find the event even though 'Health' is only in the label, not the event name
+            const eventCards = screen.getAllByTestId(/^loggable-event-card-/);
+            expect(eventCards).toHaveLength(1);
+            expect(screen.getByTestId('loggable-event-card-event-4')).toBeInTheDocument();
+        });
     });
 
     describe('combined filtering (search and label)', () => {


### PR DESCRIPTION
This pull request enhances the event filtering functionality in the `LoggableEventsList` component, allowing users to search for events not only by event name but also by label name. It updates the data model and GraphQL query to support this, and adds comprehensive tests to ensure correct behavior.

**Filtering improvements:**

* The search algorithm in `LoggableEventsList` now matches both event names and label names, improving discoverability of events. (`apps/web/src/components/LoggableEvents/LoggableEventsList.tsx`)

**Data model and query updates:**

* The `LoggableEventFragment` type and the GraphQL fragment have been updated to include the `name` field for labels, enabling label-based filtering. (`apps/web/src/components/LoggableEvents/LoggableEventsList.tsx`) [[1]](diffhunk://#diff-7d11a675a29bc1f04756cb30d2f6f13a78aba6b072cf465349cf4eaaec0c1a70R16) [[2]](diffhunk://#diff-7d11a675a29bc1f04756cb30d2f6f13a78aba6b072cf465349cf4eaaec0c1a70R27)

**Testing enhancements:**

* Added new tests to verify filtering by label name, partial label name matches, multiple events with the same label, and combined event/label name matches. (`apps/web/src/components/LoggableEvents/__tests__/LoggableEventsList.test.js`)