### PR TITLE
Forward eventcard refs down to underlying mui grid component

### DIFF
--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -23,6 +23,13 @@ module.exports = {
                 "react/prop-types": "off",
                 "react/display-name": "off"
             }
+        },
+        {
+            files: ["**/*.ts", "**/*.tsx"],
+            rules: {
+                "react/prop-types": "off",
+                "react/display-name": "off"
+            }
         }
     ],
     parser: '@typescript-eslint/parser',

--- a/apps/web/src/components/EventCards/EditEventCard.tsx
+++ b/apps/web/src/components/EventCards/EditEventCard.tsx
@@ -276,114 +276,112 @@ const EditEventCard = ({ onDismiss, eventIdToEdit }: Props) => {
 
     return (
         <ClickAwayListener onClickAway={dismissForm} mouseEvent="onMouseDown" touchEvent="onTouchStart">
-            <Box>
-                <EventCard sx={{ backgroundColor: isDarkMode ? blueGrey[900] : blueGrey[50] }}>
-                    <Box
-                        component="form"
-                        onSubmit={eventIdToEdit ? handleUpdateEventSubmit : handleNewEventSubmit}
-                        role="form"
-                        aria-label={isCreatingNewEvent ? 'Create new event' : 'Edit event'}
-                    >
-                        <CardContent>
-                            {/* Event name */}
-                            <TextField
-                                autoComplete="off"
-                                autoFocus
-                                id="new-event-input"
-                                label="Event name"
-                                {...textFieldErrorProps}
-                                value={eventNameInputValue}
-                                onChange={handleEventNameInputChange}
-                                fullWidth
-                                variant="standard"
-                                margin="normal"
-                                aria-required="true"
-                                aria-invalid={!eventNameIsValid}
-                                aria-describedby={textFieldErrorProps.error ? 'event-name-error' : undefined}
-                                color={isDarkMode ? 'primary' : 'secondary'}
-                            />
+            <EventCard sx={{ backgroundColor: isDarkMode ? blueGrey[900] : blueGrey[50] }}>
+                <Box
+                    component="form"
+                    onSubmit={eventIdToEdit ? handleUpdateEventSubmit : handleNewEventSubmit}
+                    role="form"
+                    aria-label={isCreatingNewEvent ? 'Create new event' : 'Edit event'}
+                >
+                    <CardContent>
+                        {/* Event name */}
+                        <TextField
+                            autoComplete="off"
+                            autoFocus
+                            id="new-event-input"
+                            label="Event name"
+                            {...textFieldErrorProps}
+                            value={eventNameInputValue}
+                            onChange={handleEventNameInputChange}
+                            fullWidth
+                            variant="standard"
+                            margin="normal"
+                            aria-required="true"
+                            aria-invalid={!eventNameIsValid}
+                            aria-describedby={textFieldErrorProps.error ? 'event-name-error' : undefined}
+                            color={isDarkMode ? 'primary' : 'secondary'}
+                        />
 
-                            {/* Warning threshold */}
-                            <Box aria-describedby="warning-switch-description">
-                                <FormGroup>
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={warningIsEnabled}
-                                                onChange={handleWarningToggleChange}
-                                                aria-describedby="warning-switch-description"
-                                            />
-                                        }
-                                        label="Enable warning"
-                                    />
-                                </FormGroup>
-                                <Typography id="warning-switch-description" sx={visuallyHidden}>
-                                    Toggle to enable warning notifications for this event
-                                </Typography>
-                            </Box>
-                            <Collapse in={warningIsEnabled}>
-                                <WarningThresholdForm
-                                    onChange={handleWarningThresholdChange}
-                                    initialThresholdInDays={defaultWarningThreshold}
+                        {/* Warning threshold */}
+                        <Box aria-describedby="warning-switch-description">
+                            <FormGroup>
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={warningIsEnabled}
+                                            onChange={handleWarningToggleChange}
+                                            aria-describedby="warning-switch-description"
+                                        />
+                                    }
+                                    label="Enable warning"
                                 />
-                            </Collapse>
-
-                            {/* Labels */}
-                            {!labelInputIsVisible ? (
-                                <Button
-                                    variant="text"
-                                    size="small"
-                                    sx={{ mt: 2, mb: 1 }}
-                                    onClick={() => setLabelInputIsVisible(true)}
-                                    aria-describedby="labels-section-description"
-                                    color={isDarkMode ? 'primary' : 'secondary'}
-                                >
-                                    Add labels
-                                </Button>
-                            ) : (
-                                <Box aria-labelledby="labels-section-label">
-                                    <Typography id="labels-section-label" sx={visuallyHidden}>
-                                        Event labels
-                                    </Typography>
-                                    <EventLabelAutocomplete
-                                        selectedLabels={selectedLabels}
-                                        setSelectedLabels={setSelectedLabels}
-                                        existingLabels={allEventLabels}
-                                    />
-                                </Box>
-                            )}
-                            <Typography id="labels-section-description" sx={visuallyHidden}>
-                                Add labels to categorize and organize your events
+                            </FormGroup>
+                            <Typography id="warning-switch-description" sx={visuallyHidden}>
+                                Toggle to enable warning notifications for this event
                             </Typography>
-                        </CardContent>
+                        </Box>
+                        <Collapse in={warningIsEnabled}>
+                            <WarningThresholdForm
+                                onChange={handleWarningThresholdChange}
+                                initialThresholdInDays={defaultWarningThreshold}
+                            />
+                        </Collapse>
 
-                        <CardActions>
+                        {/* Labels */}
+                        {!labelInputIsVisible ? (
                             <Button
-                                disabled={submitButtonIsDisabled}
-                                type="submit"
+                                variant="text"
                                 size="small"
-                                aria-describedby={!eventNameIsValid ? 'submit-button-disabled-reason' : undefined}
+                                sx={{ mt: 2, mb: 1 }}
+                                onClick={() => setLabelInputIsVisible(true)}
+                                aria-describedby="labels-section-description"
                                 color={isDarkMode ? 'primary' : 'secondary'}
                             >
-                                {eventIdToEdit ? 'Update' : 'Create'}
+                                Add labels
                             </Button>
-                            <Button
-                                onClick={dismissForm}
-                                size="small"
-                                aria-label="Cancel and close form"
-                                color={isDarkMode ? 'primary' : 'secondary'}
-                            >
-                                Cancel
-                            </Button>
-                            {!eventNameIsValid && (
-                                <Typography id="submit-button-disabled-reason" sx={visuallyHidden}>
-                                    Submit button is disabled because the event name is invalid
+                        ) : (
+                            <Box aria-labelledby="labels-section-label">
+                                <Typography id="labels-section-label" sx={visuallyHidden}>
+                                    Event labels
                                 </Typography>
-                            )}
-                        </CardActions>
-                    </Box>
-                </EventCard>
-            </Box>
+                                <EventLabelAutocomplete
+                                    selectedLabels={selectedLabels}
+                                    setSelectedLabels={setSelectedLabels}
+                                    existingLabels={allEventLabels}
+                                />
+                            </Box>
+                        )}
+                        <Typography id="labels-section-description" sx={visuallyHidden}>
+                            Add labels to categorize and organize your events
+                        </Typography>
+                    </CardContent>
+
+                    <CardActions>
+                        <Button
+                            disabled={submitButtonIsDisabled}
+                            type="submit"
+                            size="small"
+                            aria-describedby={!eventNameIsValid ? 'submit-button-disabled-reason' : undefined}
+                            color={isDarkMode ? 'primary' : 'secondary'}
+                        >
+                            {eventIdToEdit ? 'Update' : 'Create'}
+                        </Button>
+                        <Button
+                            onClick={dismissForm}
+                            size="small"
+                            aria-label="Cancel and close form"
+                            color={isDarkMode ? 'primary' : 'secondary'}
+                        >
+                            Cancel
+                        </Button>
+                        {!eventNameIsValid && (
+                            <Typography id="submit-button-disabled-reason" sx={visuallyHidden}>
+                                Submit button is disabled because the event name is invalid
+                            </Typography>
+                        )}
+                    </CardActions>
+                </Box>
+            </EventCard>
         </ClickAwayListener>
     );
 };

--- a/apps/web/src/components/EventCards/EventCard.tsx
+++ b/apps/web/src/components/EventCards/EventCard.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, ComponentProps } from 'react';
+import { ReactNode, ComponentProps, forwardRef } from 'react';
 
 import Card from '@mui/material/Card';
 import Grow from '@mui/material/Grow';
@@ -14,12 +14,15 @@ type Props = {
 
 /**
  * EventCard component for displaying a single event card.
+ *
+ * Passing ref to underlying MUI Grid component for use with MUI ClickAwayListener
+ * https://mui.com/material-ui/guides/composition/#caveat-with-refs
  */
-const EventCard = ({ children, ...cardProps }: Props) => {
+const EventCard = forwardRef<HTMLDivElement, Props>(({ children, ...cardProps }, ref) => {
     const { isDarkMode } = useMuiState();
 
     return (
-        <EventCardGridItem>
+        <EventCardGridItem ref={ref}>
             <Grow in>
                 <Card
                     sx={{
@@ -38,6 +41,6 @@ const EventCard = ({ children, ...cardProps }: Props) => {
             </Grow>
         </EventCardGridItem>
     );
-};
+});
 
 export default EventCard;

--- a/apps/web/src/components/EventCards/EventCardGridItem.tsx
+++ b/apps/web/src/components/EventCards/EventCardGridItem.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, forwardRef } from 'react';
 
 import Grid from '@mui/material/Grid';
 
@@ -13,12 +13,16 @@ type Props = {
 
 /**
  * EventCardGridItem component that provides a consistent Grid item wrapper for event cards.
+ *
+ * Passing ref to underlying MUI Grid component for use with MUI ClickAwayListener
+ * https://mui.com/material-ui/guides/composition/#caveat-with-refs
  */
-const EventCardGridItem = ({ children }: Props) => {
+const EventCardGridItem = forwardRef<HTMLDivElement, Props>(({ children }, ref) => {
     const { isMobile } = useMuiState();
 
     return (
         <Grid
+            ref={ref}
             role="listitem"
             size={{ xs: 12, sm: 6, md: 4, lg: 4 }}
             sx={{
@@ -29,6 +33,6 @@ const EventCardGridItem = ({ children }: Props) => {
             {children}
         </Grid>
     );
-};
+});
 
 export default EventCardGridItem;


### PR DESCRIPTION
This pull request improves the handling of refs in the Event Card components to ensure compatibility with MUI's `ClickAwayListener`, and updates ESLint configuration for TypeScript files. The most important changes are grouped below.

**Ref forwarding and composition improvements:**

* Refactored `EventCard` and `EventCardGridItem` components to use `forwardRef`, allowing refs to be passed down to the underlying MUI `Grid` component, which is necessary for proper operation with `ClickAwayListener`. Added explanatory comments and updated imports. [[1]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9L1-R1) [[2]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9R17-R25) [[3]](diffhunk://#diff-c18e7cd538431065478bd4913edb2b8985388e8f50114503502ba29aa8042fb9L41-R44) [[4]](diffhunk://#diff-ff5746d3e274950e7689e5ff4a2534b31d98ecaf1b1edfb09d1ffb622c2d6ba2L1-R1) [[5]](diffhunk://#diff-ff5746d3e274950e7689e5ff4a2534b31d98ecaf1b1edfb09d1ffb622c2d6ba2R16-R25) [[6]](diffhunk://#diff-ff5746d3e274950e7689e5ff4a2534b31d98ecaf1b1edfb09d1ffb622c2d6ba2L32-R36)
* Removed unnecessary wrapper `<Box>` elements from `EditEventCard`, so that `ClickAwayListener` wraps the correct component and works as intended after ref forwarding. [[1]](diffhunk://#diff-a581c73c4c2d884c7161ed09e5c93ab59357c15f963a0a8dd1afcd0b52a3dcfbL279) [[2]](diffhunk://#diff-a581c73c4c2d884c7161ed09e5c93ab59357c15f963a0a8dd1afcd0b52a3dcfbL386)

**ESLint configuration update:**

* Added a new ESLint override for TypeScript files (`*.ts`, `*.tsx`) to explicitly disable `react/prop-types` and `react/display-name` rules, ensuring consistent linting behavior for TS files.