### PR TITLE
add option to clear local data in errorview

### DIFF
--- a/apps/web/src/components/Views/ErrorView.tsx
+++ b/apps/web/src/components/Views/ErrorView.tsx
@@ -21,8 +21,11 @@ const ErrorView = ({ error, resetErrorBoundary }: FallbackProps) => {
     const theme = useMemo(() => createAppTheme(prefersDarkMode ? 'dark' : 'light'), [prefersDarkMode]);
 
     const handleClearLocalData = () => {
-        localStorage.removeItem('apollo-cache-persist');
-        resetErrorBoundary();
+        try {
+            localStorage.removeItem('apollo-cache-persist');
+        } finally {
+            resetErrorBoundary();
+        }
     };
 
     return (

--- a/apps/web/src/components/Views/ErrorView.tsx
+++ b/apps/web/src/components/Views/ErrorView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { ErrorOutline } from '@mui/icons-material';
-import { Box, Button, Container, Typography } from '@mui/material';
+import { Box, Button, Container, Link, Typography } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import type { FallbackProps } from 'react-error-boundary';
@@ -19,6 +19,11 @@ const ErrorView = ({ error, resetErrorBoundary }: FallbackProps) => {
     const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
     const theme = useMemo(() => createAppTheme(prefersDarkMode ? 'dark' : 'light'), [prefersDarkMode]);
+
+    const handleClearLocalData = () => {
+        localStorage.removeItem('apollo-cache-persist');
+        resetErrorBoundary();
+    };
 
     return (
         <ThemeProvider theme={theme}>
@@ -49,8 +54,16 @@ const ErrorView = ({ error, resetErrorBoundary }: FallbackProps) => {
                         </Typography>
 
                         <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-                            We&apos;re sorry, but something unexpected happened. Please try refreshing the page or
-                            contact chicanathan@gmail.com if the problem persists.
+                            We&apos;re sorry, but something unexpected happened.
+                            <br />
+                            <br />
+                            Please try again, or if the error persists, try clearing your local data.
+                            <br />
+                            If that doesn&apos;t work, please contact{' '}
+                            <Link href="mailto:chicanathan@gmail.com" underline="hover">
+                                chicanathan@gmail.com
+                            </Link>
+                            .
                         </Typography>
 
                         {process.env.NODE_ENV === 'development' && (
@@ -78,9 +91,12 @@ const ErrorView = ({ error, resetErrorBoundary }: FallbackProps) => {
                             </Box>
                         )}
 
-                        <Box sx={{ mt: 2 }}>
+                        <Box sx={{ mt: 2, display: 'flex', gap: 2, justifyContent: 'center' }}>
                             <Button variant="contained" color="primary" onClick={resetErrorBoundary}>
                                 Try Again
+                            </Button>
+                            <Button variant="outlined" color="secondary" onClick={handleClearLocalData}>
+                                Clear my local data
                             </Button>
                         </Box>
                     </Box>


### PR DESCRIPTION
This pull request enhances the error handling experience in the `ErrorView` component and improves its test coverage. The main changes include adding an option for users to clear their local data if an error persists, updating the error message for clarity, and introducing comprehensive tests for the new functionality.

**ErrorView UI and functionality improvements:**

* Added a "Clear my local data" button to the `ErrorView` component, which removes the `apollo-cache-persist` key from `localStorage` and resets the error boundary when clicked. [[1]](diffhunk://#diff-5ea964d1dd30d3f317252abb81845ff5b7c53b3893cce5347fa1c2f05e0c16dbR23-R27) [[2]](diffhunk://#diff-5ea964d1dd30d3f317252abb81845ff5b7c53b3893cce5347fa1c2f05e0c16dbL81-R100)
* Updated the error message to guide users to try clearing their local data and made the support email clickable.
* Imported the `Link` component from MUI to support the clickable email in the error message.

**Testing enhancements:**

* Added a mock implementation of `localStorage` in the test suite to isolate and verify local data clearing behavior.
* Added tests to ensure the "Clear my local data" button appears and works correctly, including verifying that only the relevant cache key is removed and the error boundary is reset. [[1]](diffhunk://#diff-439830731d89e6d291fd10f04a4b0cadb6de9ceff914e668d19264235df4ff10R76) [[2]](diffhunk://#diff-439830731d89e6d291fd10f04a4b0cadb6de9ceff914e668d19264235df4ff10R149-R175)

<img width="975" height="783" alt="image" src="https://github.com/user-attachments/assets/2bdc6f64-0d3b-4c34-bf1f-6ad292cb7c3c" />
