### PR TITLE
disable introspection in prod

### DIFF
--- a/apps/api/api/graphql.ts
+++ b/apps/api/api/graphql.ts
@@ -1,3 +1,4 @@
+import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createYoga } from 'graphql-yoga';
 
@@ -25,7 +26,7 @@ const yoga = createYoga({
         errorMessage: 'Unexpected error.',
         isDev: env.NODE_ENV === 'development' // Show full errors in development
     },
-    plugins: [contextHeadersPlugin]
+    plugins: [contextHeadersPlugin, ...(env.NODE_ENV === 'production' ? [useDisableIntrospection()] : [])]
 });
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -13,6 +13,7 @@
                 "@graphql-tools/merge": "^9.0.24",
                 "@graphql-tools/schema": "^10.0.23",
                 "@graphql-tools/utils": "^10.8.6",
+                "@graphql-yoga/plugin-disable-introspection": "^2.16.1",
                 "@prisma/client": "^6.11.1",
                 "@types/cookie": "^0.6.0",
                 "@types/jsonwebtoken": "^9.0.10",
@@ -2452,6 +2453,22 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/plugin-disable-introspection": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/plugin-disable-introspection/-/plugin-disable-introspection-2.16.1.tgz",
+            "integrity": "sha512-sL62lPhFd380eP8SrMbYhz2zaeegHBD3f0JBVHKOf8dJApnswAvRMo6UVfghwFfDFO5rEsEOIHGlIFiWDA79zg==",
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.2.0 || ^16.0.0",
+                "graphql-yoga": "^5.15.1"
             }
         },
         "node_modules/@graphql-yoga/subscription": {
@@ -7642,9 +7659,9 @@
             }
         },
         "node_modules/graphql-yoga": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-5.14.0.tgz",
-            "integrity": "sha512-OrjeyoxFM7sIrGrqSegDcdxpXUNzXOlT5q2deyAbxtwhF7z0byBhN6X8ntqLbDWKyYR+ejsK9mq+uY0eV7zkWg==",
+            "version": "5.15.1",
+            "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-5.15.1.tgz",
+            "integrity": "sha512-wCSnviFFGC4CF9lyeRNMW1p55xVWkMRLPu9iHYbBd8WCJEjduDTo3nh91sVktpbJdUQ6rxNBN6hhpTYMFZuMwg==",
             "license": "MIT",
             "dependencies": {
                 "@envelop/core": "^5.3.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,7 @@
         "@graphql-tools/merge": "^9.0.24",
         "@graphql-tools/schema": "^10.0.23",
         "@graphql-tools/utils": "^10.8.6",
+        "@graphql-yoga/plugin-disable-introspection": "^2.16.1",
         "@prisma/client": "^6.11.1",
         "@types/cookie": "^0.6.0",
         "@types/jsonwebtoken": "^9.0.10",


### PR DESCRIPTION
This pull request enhances the security of the GraphQL API by disabling introspection queries in production, which helps prevent exposure of the schema to unauthorized users. It also updates dependencies to support this new functionality.

**Security improvements:**

* Added the `@graphql-yoga/plugin-disable-introspection` package and integrated it into the GraphQL server setup to disable introspection in production environments (`apps/api/api/graphql.ts`, `apps/api/package.json`, `apps/api/package-lock.json`). [[1]](diffhunk://#diff-e918435f61bec63b508ff38ba920c79a030704a6790dd7fbcde5b1e0b15d5ac1R1) [[2]](diffhunk://#diff-e918435f61bec63b508ff38ba920c79a030704a6790dd7fbcde5b1e0b15d5ac1L28-R29) [[3]](diffhunk://#diff-2c40985d6d91eed8ae85ec1c8e754a85984ee32e156a600d2b7a467423d7e338R41) [[4]](diffhunk://#diff-8bdff5e81408664f9451fdc27067468849d65b5665c94bd7e96ba2008fcd2a4bR16) [[5]](diffhunk://#diff-8bdff5e81408664f9451fdc27067468849d65b5665c94bd7e96ba2008fcd2a4bR2458-R2473)

**Dependency updates:**

* Upgraded the `graphql-yoga` dependency from version `5.14.0` to `5.15.1` to ensure compatibility with the new plugin (`apps/api/package-lock.json`).