### PR TITLE
tweaks for chrome scrollbar in sidebar

### DIFF
--- a/apps/web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar/Sidebar.tsx
@@ -117,10 +117,27 @@ const Sidebar = ({ isCollapsed, isLoading, onCollapseSidebarClick }: Props) => {
                             <Box
                                 sx={{
                                     flex: '1 1 auto',
-                                    overflowY: 'scroll',
+                                    overflowY: 'auto',
                                     overflowX: 'hidden',
                                     minHeight: 0,
-                                    width: isMobile ? '90vw' : '350px'
+                                    width: isMobile ? '90vw' : '350px',
+                                    scrollbarWidth: 'thin', // Firefox
+                                    scrollbarColor: 'rgba(0,0,0,0.2) transparent', // Firefox
+                                    '&::-webkit-scrollbar': {
+                                        width: '6px'
+                                    },
+                                    '&::-webkit-scrollbar-track': {
+                                        background: 'transparent'
+                                    },
+                                    '&::-webkit-scrollbar-thumb': {
+                                        backgroundColor: 'rgba(0,0,0,0.2)',
+                                        borderRadius: '3px',
+                                        opacity: 0,
+                                        transition: 'opacity 0.3s'
+                                    },
+                                    '&:hover::-webkit-scrollbar-thumb': {
+                                        opacity: 1
+                                    }
                                 }}
                             >
                                 {isLoading ? (


### PR DESCRIPTION
This pull request updates the styling of the sidebar component to improve the scrollbar appearance and behavior, particularly for better usability and visual consistency across browsers.

**Sidebar scrollbar improvements:**

* Changed `overflowY` from `'scroll'` to `'auto'` to only show the vertical scrollbar when necessary.
* Added custom scrollbar styles for both Firefox and WebKit browsers, including thinner scrollbars, transparent tracks, and subtle thumb styling that only becomes visible on hover.

<img width="723" height="942" alt="image" src="https://github.com/user-attachments/assets/ed8e175c-1713-4070-99bf-c9c0958f2b56" />
