### PR TITLE
Create shared utils package for monorepo

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,4 +15,9 @@ echo "Checking API app..."
 cd ../api
 npx lint-staged
 
+# Run utils package checks
+echo "Checking utils package..."
+cd ../../packages/utils
+npx lint-staged
+
 cd ../..

--- a/packages/utils/eslint.config.js
+++ b/packages/utils/eslint.config.js
@@ -1,0 +1,77 @@
+import js from '@eslint/js';
+import typescript from '@typescript-eslint/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+import globals from 'globals';
+
+export default [
+    {
+        ignores: [
+            'node_modules/**',
+            'coverage/**',
+            'dist/**',
+            'build/**',
+            '.DS_Store',
+            '*.log*'
+        ]
+    },
+    js.configs.recommended,
+    {
+        files: ['**/*.{js,ts}'],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            parser: typescriptParser,
+            globals: {
+                ...globals.node,
+                ...globals.es2021
+            }
+        },
+        plugins: {
+            '@typescript-eslint': typescript,
+            'import': importPlugin
+        },
+        settings: {
+            'import/resolver': {
+                typescript: {},
+                node: {
+                    extensions: ['.js', '.ts']
+                }
+            }
+        },
+        rules: {
+            ...typescript.configs.recommended.rules,
+            'no-unused-vars': 'off',
+            '@typescript-eslint/no-unused-vars': ['warn'],
+            'import/order': [
+                'warn',
+                {
+                    groups: ['builtin', 'external', 'internal', 'sibling', 'parent', 'index'],
+                    'newlines-between': 'always',
+                    alphabetize: {
+                        order: 'asc',
+                        caseInsensitive: false
+                    }
+                }
+            ],
+            'import/no-duplicates': 'error',
+            'import/no-unused-modules': 'off'
+        }
+    },
+    {
+        files: ['**/*.test.{js,ts}', '**/vitest.config.ts'],
+        languageOptions: {
+            globals: {
+                ...globals.node,
+                vi: 'readonly',
+                describe: 'readonly',
+                it: 'readonly',
+                expect: 'readonly',
+                beforeEach: 'readonly',
+                afterEach: 'readonly',
+                beforeAll: 'readonly',
+                afterAll: 'readonly'
+            }
+        }
+    }
+];

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@life-event-logger/utils",
+  "version": "1.0.0",
+  "description": "Shared utilities for Life Event Logger",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "lint": "eslint --fix src",
+    "format": "prettier --write \"src/**/*.{ts,js,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,js,json}\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@eslint/js": "^9.34.0",
+    "@types/node": "^24.0.12",
+    "@typescript-eslint/eslint-plugin": "^8.40.0",
+    "@typescript-eslint/parser": "^8.41.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-prettier": "^5.5.4",
+    "globals": "^16.3.0",
+    "lint-staged": "^16.1.5",
+    "prettier": "^3.6.2",
+    "tsc-files": "^1.1.4",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "date-fns": "^4.1.0"
+  },
+  "lint-staged": {
+    "src/**/*.ts": [
+      "eslint --fix --max-warnings=0",
+      "prettier --write",
+      "tsc-files --noEmit"
+    ],
+    "src/**/*.js": [
+      "eslint --fix --max-warnings=0",
+      "prettier --write"
+    ],
+    "src/**/*.{json,md}": [
+      "prettier --write"
+    ]
+  }
+}

--- a/packages/utils/src/__tests__/time.test.ts
+++ b/packages/utils/src/__tests__/time.test.ts
@@ -1,0 +1,170 @@
+import { vi } from 'vitest';
+
+import { convertDaysToUnitAndNumber, processEventTimestamps } from '../time';
+
+describe('convertDaysToUnitAndNumber', () => {
+    it.each([
+        ['0 days', 0, { number: 0, unit: 'days' }],
+        ['single day', 1, { number: 1, unit: 'days' }],
+        ['29 days', 29, { number: 29, unit: 'days' }],
+        ['exactly 30 days', 30, { number: 1, unit: 'months' }],
+        ['45 days', 45, { number: 1, unit: 'months' }],
+        ['59 days', 59, { number: 1, unit: 'months' }],
+        ['60 days', 60, { number: 2, unit: 'months' }],
+        ['364 days', 364, { number: 12, unit: 'months' }],
+        ['exactly 365 days', 365, { number: 1, unit: 'years' }],
+        ['400 days', 400, { number: 1, unit: 'years' }],
+        ['730 days', 730, { number: 2, unit: 'years' }],
+        ['1000 days', 1000, { number: 2, unit: 'years' }]
+    ])('converts %s correctly', (_, days, expected) => {
+        expect(convertDaysToUnitAndNumber(days)).toEqual(expected);
+    });
+
+    it('uses floor division for partial units', () => {
+        expect(convertDaysToUnitAndNumber(394)).toEqual({ number: 1, unit: 'years' });
+        expect(convertDaysToUnitAndNumber(729)).toEqual({ number: 1, unit: 'years' });
+        expect(convertDaysToUnitAndNumber(89)).toEqual({ number: 2, unit: 'months' });
+    });
+});
+
+describe('processEventTimestamps', () => {
+    const mockCurrentDate = new Date('2024-01-15T00:00:00.000Z');
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(mockCurrentDate);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it.each([
+        {
+            scenario: 'empty array',
+            timestamps: [],
+            expectedSortedTimestamps: [],
+            expectedDaysSinceLastEvent: undefined
+        },
+        {
+            scenario: 'single past event',
+            timestamps: [new Date('2024-01-10T00:00:00.000Z')],
+            expectedSortedTimestamps: [new Date('2024-01-10T00:00:00.000Z')],
+            expectedDaysSinceLastEvent: 5
+        },
+        {
+            scenario: 'multiple past events unsorted',
+            timestamps: [
+                new Date('2024-01-10T00:00:00.000Z'),
+                new Date('2024-01-15T00:00:00.000Z'),
+                new Date('2024-01-05T00:00:00.000Z'),
+                new Date('2024-01-12T00:00:00.000Z')
+            ],
+            expectedSortedTimestamps: [
+                new Date('2024-01-15T00:00:00.000Z'),
+                new Date('2024-01-12T00:00:00.000Z'),
+                new Date('2024-01-10T00:00:00.000Z'),
+                new Date('2024-01-05T00:00:00.000Z')
+            ],
+            expectedDaysSinceLastEvent: 0
+        },
+        {
+            scenario: 'same day event',
+            timestamps: [new Date('2024-01-15T00:00:00.000Z'), new Date('2024-01-10T00:00:00.000Z')],
+            expectedSortedTimestamps: [new Date('2024-01-15T00:00:00.000Z'), new Date('2024-01-10T00:00:00.000Z')],
+            expectedDaysSinceLastEvent: 0
+        },
+        {
+            scenario: 'mixed future and past events',
+            timestamps: [
+                new Date('2024-01-20T00:00:00.000Z'),
+                new Date('2024-01-25T00:00:00.000Z'),
+                new Date('2024-01-10T00:00:00.000Z')
+            ],
+            expectedSortedTimestamps: [
+                new Date('2024-01-25T00:00:00.000Z'),
+                new Date('2024-01-20T00:00:00.000Z'),
+                new Date('2024-01-10T00:00:00.000Z')
+            ],
+            expectedDaysSinceLastEvent: 5
+        },
+        {
+            scenario: 'all future events',
+            timestamps: [
+                new Date('2024-01-20T00:00:00.000Z'),
+                new Date('2024-01-25T00:00:00.000Z'),
+                new Date('2024-01-30T00:00:00.000Z')
+            ],
+            expectedSortedTimestamps: [
+                new Date('2024-01-30T00:00:00.000Z'),
+                new Date('2024-01-25T00:00:00.000Z'),
+                new Date('2024-01-20T00:00:00.000Z')
+            ],
+            expectedDaysSinceLastEvent: undefined
+        },
+        {
+            scenario: 'complex mixed past and future events',
+            timestamps: [
+                new Date('2024-01-10T00:00:00.000Z'),
+                new Date('2024-01-20T00:00:00.000Z'),
+                new Date('2024-01-05T00:00:00.000Z'),
+                new Date('2024-01-25T00:00:00.000Z'),
+                new Date('2024-01-14T00:00:00.000Z')
+            ],
+            expectedSortedTimestamps: [
+                new Date('2024-01-25T00:00:00.000Z'),
+                new Date('2024-01-20T00:00:00.000Z'),
+                new Date('2024-01-14T00:00:00.000Z'),
+                new Date('2024-01-10T00:00:00.000Z'),
+                new Date('2024-01-05T00:00:00.000Z')
+            ],
+            expectedDaysSinceLastEvent: 1
+        },
+        {
+            scenario: 'timestamps with time components',
+            timestamps: [
+                new Date('2024-01-10T08:30:00.000Z'),
+                new Date('2024-01-10T23:59:59.000Z'),
+                new Date('2024-01-11T00:00:01.000Z')
+            ],
+            expectedSortedTimestamps: [
+                new Date('2024-01-11T00:00:01.000Z'),
+                new Date('2024-01-10T23:59:59.000Z'),
+                new Date('2024-01-10T08:30:00.000Z')
+            ],
+            expectedDaysSinceLastEvent: 4
+        },
+        {
+            scenario: 'events from different years',
+            timestamps: [
+                new Date('2023-12-31T00:00:00.000Z'),
+                new Date('2024-01-01T00:00:00.000Z'),
+                new Date('2023-01-15T00:00:00.000Z')
+            ],
+            expectedSortedTimestamps: [
+                new Date('2024-01-01T00:00:00.000Z'),
+                new Date('2023-12-31T00:00:00.000Z'),
+                new Date('2023-01-15T00:00:00.000Z')
+            ],
+            expectedDaysSinceLastEvent: 14
+        }
+    ])('$scenario', ({ timestamps, expectedSortedTimestamps, expectedDaysSinceLastEvent }) => {
+        const result = processEventTimestamps(timestamps);
+
+        expect(result.sortedTimestamps).toEqual(expectedSortedTimestamps);
+        expect(result.daysSinceLastEvent).toBe(expectedDaysSinceLastEvent);
+    });
+
+    it('preserves original array and does not mutate it', () => {
+        const originalTimestamps = [
+            new Date('2024-01-10T00:00:00.000Z'),
+            new Date('2024-01-15T00:00:00.000Z'),
+            new Date('2024-01-05T00:00:00.000Z')
+        ];
+        const timestampsCopy = [...originalTimestamps];
+
+        processEventTimestamps(originalTimestamps);
+
+        expect(originalTimestamps).toEqual(timestampsCopy);
+    });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './time';

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,0 +1,52 @@
+import { differenceInCalendarDays } from 'date-fns';
+
+export const DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+export const DAYS_IN_MONTH = 30;
+export const DAYS_IN_YEAR = 365;
+
+export type TimeUnit = 'days' | 'months' | 'years';
+
+/**
+ * Converts a number of days to the most appropriate time unit and number.
+ * Prioritizes years (if >= 365 days), then months (if >= 30 days),
+ * otherwise returns days. Uses floor division for intuitive conversions.
+ */
+export const convertDaysToUnitAndNumber = (days: number): { number: number; unit: TimeUnit } => {
+    if (days >= DAYS_IN_YEAR) {
+        return { number: Math.floor(days / DAYS_IN_YEAR), unit: 'years' };
+    }
+
+    if (days >= DAYS_IN_MONTH) {
+        return { number: Math.floor(days / DAYS_IN_MONTH), unit: 'months' };
+    }
+
+    return { number: days, unit: 'days' };
+};
+
+type ProcessedTimestampsPayload = {
+    /**
+     * Timestamps sorted in descending order (newest first)
+     */
+    sortedTimestamps: Date[];
+    /**
+     * Number of days since the last event record that has occured (not future dates).
+     * undefined if no past event records exist.
+     */
+    daysSinceLastEvent: number | undefined;
+};
+
+export const processEventTimestamps = (timestamps: Date[]): ProcessedTimestampsPayload => {
+    const currDate = new Date();
+    const sortedTimestamps = [...timestamps].sort((curr, next) => next.getTime() - curr.getTime());
+
+    // Find the most recent event record that has happened (not future dates)
+    const lastEventRecord = sortedTimestamps.find((eventDate) => {
+        return differenceInCalendarDays(currDate, eventDate) >= 0;
+    });
+    const daysSinceLastEvent = lastEventRecord ? differenceInCalendarDays(currDate, lastEventRecord) : undefined;
+
+    return {
+        sortedTimestamps,
+        daysSinceLastEvent
+    };
+};

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "noEmit": false,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'json', 'html'],
+            exclude: [
+                'node_modules/',
+                'dist/',
+                '**/*.config.ts',
+                '**/*.config.js',
+                '**/index.ts'
+            ]
+        }
+    }
+});


### PR DESCRIPTION
This pull request introduces a new shared utilities package for the project, `@life-event-logger/utils`, which includes time-related helper functions, configuration for linting and testing, and integration into the pre-commit workflow. The changes focus on establishing a robust foundation for code quality and reusability within the monorepo.

The package is currently not integrated into the build yet so it will just sit in the monorepo for now

**New utilities package setup and configuration:**

* Added `packages/utils/package.json` to define the new package, its dependencies, scripts for linting, formatting, testing, and lint-staged configuration for pre-commit checks.
* Created `packages/utils/tsconfig.json` for strict TypeScript settings and compatibility with modern module resolution.
* Added `packages/utils/eslint.config.js` for consistent linting across JS/TS files, including recommended rules and import order enforcement.
* Added `packages/utils/vitest.config.ts` for test runner configuration, coverage reporting, and test environment setup.

**Time utility functions and tests:**

* Implemented `convertDaysToUnitAndNumber` and `processEventTimestamps` in `packages/utils/src/time.ts`, providing helpers for time calculations and event timestamp processing.
* Added comprehensive unit tests for these utilities in `packages/utils/src/__tests__/time.test.ts`, covering various edge cases and ensuring non-mutating behavior.
* Exposed utility functions via `packages/utils/src/index.ts` for easy import.

**Monorepo integration:**

* Updated `.husky/pre-commit` to run lint-staged checks for the new utils package, ensuring code quality before commits.