### PR TITLE
move cron sched to 12am pst

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -10,7 +10,7 @@
     "crons": [
         {
             "path": "/api/cron/daily",
-            "schedule": "0 8 * * *"
+            "schedule": "0 7 * * *"
         }
     ]
 }


### PR DESCRIPTION
This pull request makes a minor configuration change to the scheduled daily cron job in the `apps/api/vercel.json` file. The job will now run one hour earlier each day.

* Changed the schedule for the `/api/cron/daily` cron job from 8:00 AM to 7:00 AM utc (12am pst)