### PR TITLE
add checkbox to let users stay signed in for 30 days

### DIFF
--- a/apps/api/src/schema/user/index.ts
+++ b/apps/api/src/schema/user/index.ts
@@ -38,7 +38,6 @@ const GoogleOAuthLoginMutationSchema = z.object({
     rememberMe: z.boolean().optional().default(false)
 });
 
-// Cookie configuration function to support dynamic maxAge based on rememberMe
 const getCookieOptions = (rememberMe: boolean = false) => {
     // Use absolute max days for cookie expiration when rememberMe is true
     const maxAgeDays = rememberMe ? env.REFRESH_TOKEN_ABSOLUTE_MAX_DAYS : env.REFRESH_TOKEN_EXPIRES_IN_DAYS;

--- a/apps/web/src/components/Views/LoginView.tsx
+++ b/apps/web/src/components/Views/LoginView.tsx
@@ -8,9 +8,11 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
+import Checkbox from '@mui/material/Checkbox';
 import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
@@ -29,6 +31,7 @@ import { fullViewportHeight } from '../../utils/theme';
 const LoginView = () => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [rememberMe, setRememberMe] = useState(false);
     const { setAuthData, setOfflineMode } = useAuth();
     const { loginMutation } = useAuthMutations();
     const theme = useTheme();
@@ -47,7 +50,8 @@ const LoginView = () => {
                 variables: {
                     input: {
                         googleToken: credentialResponse.credential,
-                        clientType: 'WEB'
+                        clientType: 'WEB',
+                        rememberMe
                     }
                 }
             });
@@ -182,6 +186,23 @@ const LoginView = () => {
                                                     shape="rectangular"
                                                     theme="outline"
                                                     size="large"
+                                                />
+                                            </Box>
+
+                                            <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
+                                                <FormControlLabel
+                                                    control={
+                                                        <Checkbox
+                                                            checked={rememberMe}
+                                                            onChange={(e) => setRememberMe(e.target.checked)}
+                                                            color="primary"
+                                                        />
+                                                    }
+                                                    label={
+                                                        <Typography variant="body2" color="text.secondary">
+                                                            Keep me signed in for 30 days
+                                                        </Typography>
+                                                    }
                                                 />
                                             </Box>
 

--- a/apps/web/src/components/Views/__tests__/LoginView.test.jsx
+++ b/apps/web/src/components/Views/__tests__/LoginView.test.jsx
@@ -132,7 +132,8 @@ describe('LoginView', () => {
                 variables: {
                     input: {
                         googleToken: 'mock-credential',
-                        clientType: 'WEB'
+                        clientType: 'WEB',
+                        rememberMe: false
                     }
                 }
             });
@@ -176,7 +177,8 @@ describe('LoginView', () => {
                 variables: {
                     input: {
                         googleToken: 'mock-credential',
-                        clientType: 'WEB'
+                        clientType: 'WEB',
+                        rememberMe: false
                     }
                 }
             });
@@ -318,6 +320,52 @@ describe('LoginView', () => {
             expect(consoleErrorSpy).toHaveBeenCalledWith('Google login failed');
 
             consoleErrorSpy.mockRestore();
+        });
+
+        it('sends rememberMe as true when checkbox is checked', async () => {
+            let resolveMockLoginMutation;
+            const loginPromise = new Promise((resolve) => {
+                resolveMockLoginMutation = resolve;
+            });
+            mockLoginMutation.mockReturnValue(loginPromise);
+
+            renderWithProviders();
+
+            // Check the "Keep me signed in" checkbox
+            const rememberMeCheckbox = screen.getByRole('checkbox', { name: /keep me signed in/i });
+            await user.click(rememberMeCheckbox);
+            expect(rememberMeCheckbox).toBeChecked();
+
+            // Trigger Google login
+            const googleLoginButton = screen.getByTestId('google-login');
+            await user.click(googleLoginButton);
+
+            // Should call loginMutation with rememberMe: true
+            expect(mockLoginMutation).toHaveBeenCalledWith({
+                variables: {
+                    input: {
+                        googleToken: 'mock-credential',
+                        clientType: 'WEB',
+                        rememberMe: true
+                    }
+                }
+            });
+
+            // Resolve the promise to clean up
+            await act(async () => {
+                resolveMockLoginMutation({
+                    data: {
+                        googleOAuthLoginMutation: {
+                            accessToken: 'mock-access-token',
+                            user: {
+                                id: 'user-1',
+                                email: 'test@example.com',
+                                name: 'Test User'
+                            }
+                        }
+                    }
+                });
+            });
         });
     });
 


### PR DESCRIPTION
This pull request introduces a "Keep me signed in" (remember me) feature to the login flow, allowing users to stay authenticated for an extended period. The implementation includes UI changes, mutation updates, and corresponding test coverage.

**Feature: Remember Me option in login**

* Added a "Keep me signed in for 30 days" checkbox to the `LoginView` UI using `Checkbox` and `FormControlLabel` from MUI. The state is managed with a new `rememberMe` variable. [[1]](diffhunk://#diff-eded175702949b9653eb3f4e9dd414c700b38be37e7ac254a7a37e9784fd1870R11-R15) [[2]](diffhunk://#diff-eded175702949b9653eb3f4e9dd414c700b38be37e7ac254a7a37e9784fd1870R34) [[3]](diffhunk://#diff-eded175702949b9653eb3f4e9dd414c700b38be37e7ac254a7a37e9784fd1870R192-R208)
* Modified the Google OAuth login mutation input to send the `rememberMe` value from the UI to the backend.

**Backend and schema updates**

* Ensured the backend cookie configuration function supports dynamic expiration based on the `rememberMe` parameter.

**Testing improvements**

* Updated login mutation tests to include the `rememberMe` field, with new coverage for both checked and unchecked states. Added a test to verify the correct value is sent when the checkbox is checked. [[1]](diffhunk://#diff-37514064a36494aa87c22015e746a10f00dc1dc3a47a1c1d3d5046867c3f1e5cL135-R136) [[2]](diffhunk://#diff-37514064a36494aa87c22015e746a10f00dc1dc3a47a1c1d3d5046867c3f1e5cL179-R181) [[3]](diffhunk://#diff-37514064a36494aa87c22015e746a10f00dc1dc3a47a1c1d3d5046867c3f1e5cR324-R369)

<img width="602" height="612" alt="image" src="https://github.com/user-attachments/assets/cf1cd215-cb31-482f-bcc9-75939bc8e049" />
