### PR TITLE
add snackbar for unauthorized gql queries

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
         "@life-event-logger/utils": "^1.0.0",
         "@mui/icons-material": "^7.0.0",
         "@mui/lab": "^7.0.0-beta.14",
-        "@mui/material": "^7.0.0",
+        "@mui/material": "^7.3.2",
         "@mui/x-date-pickers": "^7.0.0",
         "@react-oauth/google": "^0.12.2",
         "@sentry/react": "^10.8.0",

--- a/apps/web/src/components/EventLoggerPage.tsx
+++ b/apps/web/src/components/EventLoggerPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from 'react';
 
 import { ApolloProvider, ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { Snackbar } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 
 import LoggableEventsGQL from './LoggableEvents/LoggableEventsGQL';
@@ -21,7 +22,7 @@ import { createAppTheme } from '../utils/theme';
  * The theme includes custom styles for error states in form components when in dark mode.
  */
 const EventLoggerPage = () => {
-    const { theme: mode } = useViewOptions();
+    const { theme: mode, snackbarMessage, snackbarDuration, hideSnackbar } = useViewOptions();
     const { user, isOfflineMode, isInitializing } = useAuth();
     const [apolloClient, setApolloClient] = useState<ApolloClient<NormalizedCacheObject> | null>(null);
 
@@ -39,7 +40,30 @@ const EventLoggerPage = () => {
 
     return (
         <ThemeProvider theme={appTheme}>
-            <ApolloProvider client={apolloClient}>{user ? <LoggableEventsGQL /> : <LoginView />}</ApolloProvider>
+            <ApolloProvider client={apolloClient}>
+                {user ? <LoggableEventsGQL /> : <LoginView />}
+                <Snackbar
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'right'
+                    }}
+                    slotProps={{
+                        clickAwayListener: {
+                            /* v8 ignore start */
+                            onClickAway: (event) => {
+                                // https://mui.com/material-ui/react-snackbar/#preventing-default-click-away-event
+                                // @ts-expect-error - defaultMuiPrevented works but isn't in the type definitions
+                                event.defaultMuiPrevented = true;
+                            }
+                            /* v8 ignore end */
+                        }
+                    }}
+                    open={Boolean(snackbarMessage)}
+                    message={snackbarMessage}
+                    autoHideDuration={snackbarDuration}
+                    onClose={hideSnackbar}
+                />
+            </ApolloProvider>
         </ThemeProvider>
     );
 };

--- a/apps/web/src/components/LoggableEvents/LoggableEventsGQL.tsx
+++ b/apps/web/src/components/LoggableEvents/LoggableEventsGQL.tsx
@@ -2,10 +2,10 @@ import { gql, useQuery } from '@apollo/client';
 import invariant from 'tiny-invariant';
 
 import { useAuth } from '../../providers/AuthProvider';
+import { useViewOptions } from '../../providers/ViewOptionsProvider';
 import LoggableEventCard from '../EventCards/LoggableEventCard';
 import EventLabel from '../EventLabels/EventLabel';
 import LoggableEventsView from '../Views/LoggableEventsView';
-
 
 export const GET_LOGGABLE_EVENTS_FOR_USER = gql`
     query GetLoggableEventsForUser {
@@ -31,7 +31,8 @@ export const GET_LOGGABLE_EVENTS_FOR_USER = gql`
  * This component controls the loading state and error state of the main view based on the fetch status.
  */
 const LoggableEventsGQL = () => {
-    const { user, isOfflineMode } = useAuth();
+    const { user, isOfflineMode, clearAuthData } = useAuth();
+    const { showSnackbar } = useViewOptions();
 
     invariant(user, 'User is not authenticated');
 
@@ -39,6 +40,12 @@ const LoggableEventsGQL = () => {
         // In offline mode, only read from cache, don't try network
         fetchPolicy: isOfflineMode ? 'cache-only' : 'cache-and-network'
     });
+
+    if (error && error.graphQLErrors.some((e) => e.extensions?.code === 'UNAUTHORIZED')) {
+        // Send user back to login screen
+        clearAuthData();
+        showSnackbar('You have been logged out due to inactivity.');
+    }
 
     return <LoggableEventsView isLoading={loading} isShowingFetchError={Boolean(error && !isOfflineMode)} />;
 };

--- a/apps/web/src/mocks/providers.ts
+++ b/apps/web/src/mocks/providers.ts
@@ -25,6 +25,10 @@ export const createMockViewOptionsContextValue = (
         enableDarkTheme: () => {},
         activeEventLabelId: createMockEventLabel().id,
         setActiveEventLabelId: (_id) => {}, // eslint-disable-line @typescript-eslint/no-unused-vars
+        snackbarMessage: null,
+        snackbarDuration: 5000,
+        showSnackbar: (_message, _duration) => {}, // eslint-disable-line @typescript-eslint/no-unused-vars
+        hideSnackbar: () => {},
         ...overrides
     };
 };

--- a/apps/web/src/providers/ViewOptionsProvider.tsx
+++ b/apps/web/src/providers/ViewOptionsProvider.tsx
@@ -5,12 +5,18 @@ import invariant from 'tiny-invariant';
 
 type AppTheme = 'light' | 'dark';
 
+const DEFAULT_SNACKBAR_DURATION = 5000;
+
 export type ViewOptionsContextType = {
     theme: AppTheme;
     enableLightTheme: () => void;
     enableDarkTheme: () => void;
     activeEventLabelId: string | null;
     setActiveEventLabelId: (id: string | null) => void;
+    snackbarMessage: string | null;
+    snackbarDuration: number;
+    showSnackbar: (message: string, duration?: number) => void;
+    hideSnackbar: () => void;
 };
 
 export const ViewOptionsContext = createContext<ViewOptionsContextType | null>(null);
@@ -35,6 +41,15 @@ const ViewOptionsProvider = ({ children }: Props) => {
     const enableLightTheme = () => setTheme('light');
     const enableDarkTheme = () => setTheme('dark');
 
+    // Snackbar configuration
+    const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
+    const [snackbarDuration, setSnackbarDuration] = useState<number>(DEFAULT_SNACKBAR_DURATION);
+    const showSnackbar = (message: string, duration: number = DEFAULT_SNACKBAR_DURATION) => {
+        setSnackbarMessage(message);
+        setSnackbarDuration(duration);
+    };
+    const hideSnackbar = () => setSnackbarMessage(null);
+
     const [activeEventLabelId, setActiveEventLabelId] = useState<string | null>(null);
 
     const contextValue = {
@@ -42,7 +57,11 @@ const ViewOptionsProvider = ({ children }: Props) => {
         enableLightTheme,
         enableDarkTheme,
         activeEventLabelId,
-        setActiveEventLabelId
+        setActiveEventLabelId,
+        snackbarMessage,
+        snackbarDuration,
+        showSnackbar,
+        hideSnackbar
     };
 
     return <ViewOptionsContext.Provider value={contextValue}>{children}</ViewOptionsContext.Provider>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,7 @@
         "@life-event-logger/utils": "^1.0.0",
         "@mui/icons-material": "^7.0.0",
         "@mui/lab": "^7.0.0-beta.14",
-        "@mui/material": "^7.0.0",
+        "@mui/material": "^7.3.2",
         "@mui/x-date-pickers": "^7.0.0",
         "@react-oauth/google": "^0.12.2",
         "@sentry/react": "^10.8.0",
@@ -3154,9 +3154,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.1.tgz",
-      "integrity": "sha512-+mIK1Z0BhOaQ0vCgOkT1mSrIpEHLo338h4/duuL4TBLXPvUMit732mnwJY3W40Avy30HdeSfwUAAGRkKmwRaEQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.2.tgz",
+      "integrity": "sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3234,16 +3234,16 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.1.tgz",
-      "integrity": "sha512-Xf6Shbo03YmcBedZMwSpEFOwpYDtU7tC+rhAHTrA9FHk0FpsDqiQ9jUa1j/9s3HLs7KWb5mDcGnlwdh9Q9KAag==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.2.tgz",
+      "integrity": "sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/core-downloads-tracker": "^7.3.1",
-        "@mui/system": "^7.3.1",
-        "@mui/types": "^7.4.5",
-        "@mui/utils": "^7.3.1",
+        "@babel/runtime": "^7.28.3",
+        "@mui/core-downloads-tracker": "^7.3.2",
+        "@mui/system": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -3262,7 +3262,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.1",
+        "@mui/material-pigment-css": "^7.3.2",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3283,13 +3283,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.1.tgz",
-      "integrity": "sha512-WU3YLkKXii/x8ZEKnrLKsPwplCVE11yZxUvlaaZSIzCcI3x2OdFC8eMlNy74hVeUsYQvzzX1Es/k4ARPlFvpPQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.2.tgz",
+      "integrity": "sha512-ha7mFoOyZGJr75xeiO9lugS3joRROjc8tG1u4P50dH0KR7bwhHznVMcYg7MouochUy0OxooJm/OOSpJ7gKcMvg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/utils": "^7.3.1",
+        "@babel/runtime": "^7.28.3",
+        "@mui/utils": "^7.3.2",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3310,12 +3310,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.1.tgz",
-      "integrity": "sha512-Nqo6OHjvJpXJ1+9TekTE//+8RybgPQUKwns2Lh0sq+8rJOUSUKS3KALv4InSOdHhIM9Mdi8/L7LTF1/Ky6D6TQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.2.tgz",
+      "integrity": "sha512-PkJzW+mTaek4e0nPYZ6qLnW5RGa0KN+eRTf5FA2nc7cFZTeM+qebmGibaTLrgQBy3UpcpemaqfzToBNkzuxqew==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
+        "@babel/runtime": "^7.28.3",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -3344,16 +3344,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.1.tgz",
-      "integrity": "sha512-mIidecvcNVpNJMdPDmCeoSL5zshKBbYPcphjuh6ZMjhybhqhZ4mX6k9zmIWh6XOXcqRQMg5KrcjnO0QstrNj3w==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.2.tgz",
+      "integrity": "sha512-9d8JEvZW+H6cVkaZ+FK56R53vkJe3HsTpcjMUtH8v1xK6Y1TjzHdZ7Jck02mGXJsE6MQGWVs3ogRHTQmS9Q/rA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/private-theming": "^7.3.1",
-        "@mui/styled-engine": "^7.3.1",
-        "@mui/types": "^7.4.5",
-        "@mui/utils": "^7.3.1",
+        "@babel/runtime": "^7.28.3",
+        "@mui/private-theming": "^7.3.2",
+        "@mui/styled-engine": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3384,12 +3384,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.5.tgz",
-      "integrity": "sha512-ZPwlAOE3e8C0piCKbaabwrqZbW4QvWz0uapVPWya7fYj6PeDkl5sSJmomT7wjOcZGPB48G/a6Ubidqreptxz4g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
+      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2"
+        "@babel/runtime": "^7.28.3"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3401,13 +3401,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-/31y4wZqVWa0jzMnzo6JPjxwP6xXy4P3+iLbosFg/mJQowL1KIou0LC+lquWW60FKVbKz5ZUWBg2H3jausa0pw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/types": "^7.4.5",
+        "@babel/runtime": "^7.28.3",
+        "@mui/types": "^7.4.6",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",


### PR DESCRIPTION
This pull request introduces global snackbar notification support to the app, allowing components to trigger user feedback messages (such as errors or success notifications) that are displayed at the bottom right of the UI. The snackbar state and actions are managed via the `ViewOptionsProvider` context, and comprehensive tests have been added to ensure correct behavior. Additionally, unauthorized GraphQL errors now log out the user and show a notification. The most important changes are grouped below.

**Snackbar Notification System**

* Added snackbar state (`snackbarMessage`, `snackbarDuration`) and actions (`showSnackbar`, `hideSnackbar`) to `ViewOptionsProvider`, making them available throughout the app. [[1]](diffhunk://#diff-98bd4645176fa94b54798f802b341645d629046a435bd0c5d1670d2b91a7f6b9R8-R19) [[2]](diffhunk://#diff-98bd4645176fa94b54798f802b341645d629046a435bd0c5d1670d2b91a7f6b9R44-R64)
* Integrated a global `Snackbar` component into `EventLoggerPage`, displaying messages based on context state and handling auto-hide and click-away events. [[1]](diffhunk://#diff-a9d3687dd8cd78ae4f86e3f243b8a01ffb86f3591d536b6a92952372c8a05990R4) [[2]](diffhunk://#diff-a9d3687dd8cd78ae4f86e3f243b8a01ffb86f3591d536b6a92952372c8a05990L24-R25) [[3]](diffhunk://#diff-a9d3687dd8cd78ae4f86e3f243b8a01ffb86f3591d536b6a92952372c8a05990L42-R66)
* Updated mock provider and context value utilities to support snackbar props for testing.
* Added and updated tests for snackbar functionality in `EventLoggerPage` and `ViewOptionsProvider`, covering display, duration, and hide logic. [[1]](diffhunk://#diff-58dae1b507c070a72d07e68ddde992578d7da0fa75a36ba5721e73c77bb12121R90-R139) [[2]](diffhunk://#diff-382f23da41d41cea743ff26607f815619a08af326da7f04f80bbfd93fb959684R186-R285)

**Error Handling Improvements**

* In `LoggableEventsGQL`, unauthorized GraphQL errors now trigger logout and display a snackbar notification; tests added to verify this behavior and distinguish from other error types. [[1]](diffhunk://#diff-370d8dd09e48283be9a10fb557bf4db726874a9a0585ae23adc2cb797223e530R5-L9) [[2]](diffhunk://#diff-370d8dd09e48283be9a10fb557bf4db726874a9a0585ae23adc2cb797223e530L34-R35) [[3]](diffhunk://#diff-370d8dd09e48283be9a10fb557bf4db726874a9a0585ae23adc2cb797223e530R44-R49) [[4]](diffhunk://#diff-fdc2b253da247d8f6dbc83e35d37ec49cd6ffc9ad256863f574e64b8f2023f9fR51-R66) [[5]](diffhunk://#diff-fdc2b253da247d8f6dbc83e35d37ec49cd6ffc9ad256863f574e64b8f2023f9fR151-R194)

**Testing and Miscellaneous**

* Extended context and component tests to cover snackbar state and actions, including custom durations and integration with other context features. [[1]](diffhunk://#diff-382f23da41d41cea743ff26607f815619a08af326da7f04f80bbfd93fb959684L53-R57) [[2]](diffhunk://#diff-382f23da41d41cea743ff26607f815619a08af326da7f04f80bbfd93fb959684L157-R165) [[3]](diffhunk://#diff-382f23da41d41cea743ff26607f815619a08af326da7f04f80bbfd93fb959684R299-R311) [[4]](diffhunk://#diff-382f23da41d41cea743ff26607f815619a08af326da7f04f80bbfd93fb959684R323-R326) [[5]](diffhunk://#diff-382f23da41d41cea743ff26607f815619a08af326da7f04f80bbfd93fb959684R348-R356)
* Updated MUI dependency version for `@mui/material` to ensure compatibility with the snackbar implementation.

<img width="1490" height="859" alt="image" src="https://github.com/user-attachments/assets/6a6c2fc5-dda8-4fa1-b258-29f43a29e1d6" />
